### PR TITLE
Questions about rusb_async implementation and usage

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,18 +13,18 @@ jobs:
   check-code:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: true
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
 
-    - name: Install
-      run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libusb-1.0-0-dev
+      - name: Install
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libusb-1.0-0-dev
 
-    - name: Run check and format
-      run: |
-        cargo check --all-targets --examples
-        cargo fmt --check
+      - name: Run check and format
+        run: |
+          cargo check --all-targets --examples
+          cargo fmt --check
 
   build:
     needs: [check-code]
@@ -34,12 +34,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            apt: 'libusb-1.0-0-dev'
+            apt: "libusb-1.0-0-dev"
             experimental: false
             features: ""
 
           - os: ubuntu-latest
-            apt: 'libudev-dev'
+            apt: "libudev-dev"
             experimental: false
             features: ""
 
@@ -67,7 +67,7 @@ jobs:
             features: ""
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 0.9.4
+
+* bLength, bDescriptorType and wTotalLength to descriptors [#185]
+* Use &self reference for all DeviceHandle methods [#186]
+* fix: panic when trying to iterate over an interface with zero endpoints [#195]
+* Log callback API added [#194]
+* Bump libusb1-sys 0.7.0 [#205]
+
+[#185]: https://github.com/a1ien/rusb/pull/185
+[#186]: https://github.com/a1ien/rusb/pull/186
+[#195]: https://github.com/a1ien/rusb/pull/195
+[#194]: https://github.com/a1ien/rusb/pull/194
+[#205]: https://github.com/a1ien/rusb/pull/205
+
 ## 0.9.3
 * impl serde::{Serialize, Deserialize} for public enums [#167]
 * Update deprecated doc link about language identifiers [#165]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changes
 
-## unreleased
+## 0.9.2
+* Random corrections around the code [#127]
+* examples: list_devices: Add vendor and product name [#128]
+* examples: read_devices: Improve usage [#125]
+* context: create rusb `Context` from existing `libusb_context` [#135]
+* `new` now uses `from_raw` [#135]
+* Fix stack use after scope in tests [#138]
+* Fix United Kingdom misspelling in languages docs [#137]
+* fields.rs: Make request_type function a const fn [#142]
+* Increase endpoint descriptor's lifetime [#149]
+* Fix timeout documentation [#151]
+
+[#127]: https://github.com/a1ien/rusb/pull/116
+[#128]: https://github.com/a1ien/rusb/pull/116
+[#125]: https://github.com/a1ien/rusb/pull/116
+[#135]: https://github.com/a1ien/rusb/pull/116
+[#138]: https://github.com/a1ien/rusb/pull/116
+[#137]: https://github.com/a1ien/rusb/pull/116
+[#142]: https://github.com/a1ien/rusb/pull/116
+[#149]: https://github.com/a1ien/rusb/pull/116
+[#151]: https://github.com/a1ien/rusb/pull/116
+
+## 0.9.1
 * impl Ord and PartialOrd for Version [#116]
 
 [#116]: https://github.com/a1ien/rusb/pull/116

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@
 * Increase endpoint descriptor's lifetime [#149]
 * Fix timeout documentation [#151]
 
-[#127]: https://github.com/a1ien/rusb/pull/116
-[#128]: https://github.com/a1ien/rusb/pull/116
-[#125]: https://github.com/a1ien/rusb/pull/116
-[#135]: https://github.com/a1ien/rusb/pull/116
-[#138]: https://github.com/a1ien/rusb/pull/116
-[#137]: https://github.com/a1ien/rusb/pull/116
-[#142]: https://github.com/a1ien/rusb/pull/116
-[#149]: https://github.com/a1ien/rusb/pull/116
-[#151]: https://github.com/a1ien/rusb/pull/116
+[#127]: https://github.com/a1ien/rusb/pull/127
+[#128]: https://github.com/a1ien/rusb/pull/128
+[#125]: https://github.com/a1ien/rusb/pull/125
+[#135]: https://github.com/a1ien/rusb/pull/135
+[#138]: https://github.com/a1ien/rusb/pull/135
+[#137]: https://github.com/a1ien/rusb/pull/137
+[#142]: https://github.com/a1ien/rusb/pull/142
+[#149]: https://github.com/a1ien/rusb/pull/149
+[#151]: https://github.com/a1ien/rusb/pull/151
 
 ## 0.9.1
 * impl Ord and PartialOrd for Version [#116]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 0.9.3
+* impl serde::{Serialize, Deserialize} for public enums [#167]
+* Update deprecated doc link about language identifiers [#165]
+* Fix changelog URLs for 0.9.2 [#164]
+
+
+[#167]: https://github.com/a1ien/rusb/pull/167
+[#165]: https://github.com/a1ien/rusb/pull/165
+[#164]: https://github.com/a1ien/rusb/pull/164
+
 ## 0.9.2
 * Random corrections around the code [#127]
 * examples: list_devices: Add vendor and product name [#128]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
-libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
+libusb1-sys = { path = "libusb1-sys", version = "0.6.4" }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"
@@ -21,7 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
-libusb1-sys = { path = "libusb1-sys", version = "0.6.4" }
+libusb1-sys = { path = "libusb1-sys", version = "0.7" }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ libc = "0.2"
 
 [dev-dependencies]
 regex = "1"
-usb-ids = "0.2.2"
+usb-ids = "1.2023.0"

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -94,6 +94,8 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
         };
 
     println!("Device Descriptor:");
+    println!("  bLength              {:3}", device_desc.length());
+    println!("  bDescriptorType      {:3}", device_desc.descriptor_type());
     println!(
         "  bcdUSB             {:2}.{}{}",
         device_desc.usb_version().major(),
@@ -147,6 +149,12 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
 
 fn print_config<T: UsbContext>(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice<T>>) {
     println!("  Config Descriptor:");
+    println!("    bLength              {:3}", config_desc.length());
+    println!(
+        "    bDescriptorType      {:3}",
+        config_desc.descriptor_type()
+    );
+    println!("    wTotalLength      {:#06x}", config_desc.total_length());
     println!(
         "    bNumInterfaces       {:3}",
         config_desc.num_interfaces()
@@ -177,6 +185,11 @@ fn print_interface<T: UsbContext>(
     handle: &mut Option<UsbDevice<T>>,
 ) {
     println!("    Interface Descriptor:");
+    println!("      bLength              {:3}", interface_desc.length());
+    println!(
+        "      bDescriptorType      {:3}",
+        interface_desc.descriptor_type()
+    );
     println!(
         "      bInterfaceNumber     {:3}",
         interface_desc.interface_number()
@@ -219,6 +232,11 @@ fn print_interface<T: UsbContext>(
 
 fn print_endpoint(endpoint_desc: &EndpointDescriptor) {
     println!("      Endpoint Descriptor:");
+    println!("        bLength              {:3}", endpoint_desc.length());
+    println!(
+        "        bDescriptorType      {:3}",
+        endpoint_desc.descriptor_type()
+    );
     println!(
         "        bEndpointAddress    {:#04x} EP {} {:?}",
         endpoint_desc.address(),

--- a/libusb1-sys/CHANGELOG.md
+++ b/libusb1-sys/CHANGELOG.md
@@ -1,6 +1,41 @@
 # Changes
 
-## unreleased
+## 0.7.0
+
+* fix: Add missing fields to libusb_bos_descriptor and libusb_bos_dev_capability_descriptor [#161]
+* Bump libusb to 1.0.27 [#201]
+* Remove unneeded mut [#204]
+
+[#161]: https://github.com/a1ien/rusb/pull/161
+[#201]: https://github.com/a1ien/rusb/pull/201
+[#204]: https://github.com/a1ien/rusb/pull/204
+
+## 0.6.5
+* Support pkg_config for MSVC. [#191]
+* Fix package detection and build when cross-compiling from MSVC to GNU [#180]
+* libusb_set_iso_packet_lengths panics on debug builds in newest nightly (2024-03-27) [#199]
+* Added libusb_free_pollfds() in the available FFI methods. [#203]
+
+[#191]: https://github.com/a1ien/rusb/pull/191
+[#180]: https://github.com/a1ien/rusb/pull/180
+[#199]: https://github.com/a1ien/rusb/pull/199
+[#203]: https://github.com/a1ien/rusb/pull/203
+
+## 0.6.3-0.6.4
+* Patch for macOS Big Sur and newer allowing to link statically [#133]
+* Add libudev include paths as specified by pkg-config [#140]
+
+[#133]: https://github.com/a1ien/rusb/pull/133
+[#140]: https://github.com/a1ien/rusb/pull/140
+
+
+## 0.6.2
+* Rename compiled library when vendored libusb is used [#130]
+
+[#130]: https://github.com/a1ien/rusb/pull/130
+
+## 0.6.1
+* Add LIBUSB_OPTION_NO_DEVICE_DISCOVERY constant
 * Bump vendored libusb version from 1.0.24 to 1.0.25 [#119]
 
 [#119]: https://github.com/a1ien/rusb/pull/119

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -39,7 +39,7 @@ vendored = []
 [dependencies]
 libc = "0.2"
 
-[target.'cfg(target_env = "msvc")'.build-dependencies]
+[target.'cfg(target_os = "windows")'.build-dependencies]
 vcpkg = "0.2"
 
 [build-dependencies]

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libusb1-sys"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>",
             "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "FFI bindings for libusb."

--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -24,8 +24,12 @@ fn find_libusb_pkg(_statik: bool) -> bool {
     match vcpkg::Config::new().find_package("libusb") {
         Ok(_) => true,
         Err(e) => {
-            println!("Can't find libusb pkg: {:?}", e);
-            false
+            if pkg_config::probe_library("libusb-1.0").is_ok() {
+                true
+            } else {
+                println!("Can't find libusb pkg: {:?}", e);
+                false
+            }
         }
     }
 }

--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-static VERSION: &str = "1.0.24";
+static VERSION: &str = "1.0.27";
 
 fn link(name: &str, bundled: bool) {
     use std::env::var;

--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -158,14 +158,16 @@ fn make_source() {
             Some("__attribute__((visibility(\"default\")))"),
         );
 
-        if let Ok(lib) = pkg_config::probe_library("libudev") {
-            base_config.define("USE_UDEV", Some("1"));
-            base_config.define("HAVE_LIBUDEV", Some("1"));
-            base_config.file(libusb_source.join("libusb/os/linux_udev.c"));
-            for path in lib.include_paths {
-                base_config.include(path.to_str().unwrap());
-            }
-        };
+        if std::env::var("CARGO_CFG_TARGET_OS") != Ok("android".into()) {
+            if let Ok(lib) = pkg_config::probe_library("libudev") {
+                base_config.define("USE_UDEV", Some("1"));
+                base_config.define("HAVE_LIBUDEV", Some("1"));
+                base_config.file(libusb_source.join("libusb/os/linux_udev.c"));
+                for path in lib.include_paths {
+                    base_config.include(path.to_str().unwrap());
+                }
+            };
+        }
 
         println!("Including posix!");
         base_config.file(libusb_source.join("libusb/os/events_posix.c"));

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -658,10 +658,7 @@ pub unsafe fn libusb_fill_iso_transfer(
 #[inline]
 pub unsafe fn libusb_set_iso_packet_lengths(transfer: *mut libusb_transfer, length: c_uint) {
     for i in 0..(*transfer).num_iso_packets {
-        (*transfer)
-            .iso_packet_desc
-            .get_unchecked_mut(i as usize)
-            .length = length;
+        (*(*transfer).iso_packet_desc.as_mut_ptr().add(i as usize)).length = length;
     }
 }
 
@@ -675,10 +672,7 @@ pub unsafe fn libusb_get_iso_packet_buffer(
     }
     let mut offset = 0;
     for i in 0..packet {
-        offset += (*transfer)
-            .iso_packet_desc
-            .get_unchecked_mut(i as usize)
-            .length;
+        offset += (*(*transfer).iso_packet_desc.as_mut_ptr().add(i as usize)).length;
     }
 
     (*transfer).buffer.add(offset as usize)
@@ -695,5 +689,5 @@ pub unsafe fn libusb_get_iso_packet_buffer_simple(
 
     (*transfer)
         .buffer
-        .add(((*transfer).iso_packet_desc.get_unchecked_mut(0).length * packet) as usize)
+        .add(((*(*transfer).iso_packet_desc.as_mut_ptr().add(0)).length * packet) as usize)
 }

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -126,6 +126,7 @@ pub struct libusb_bos_dev_capability_descriptor {
     pub bLength: u8,
     pub bDescriptorType: u8,
     pub bDevCapabilityType: u8,
+    pub dev_capability_data: [u8; 0],
 }
 
 #[allow(non_snake_case)]
@@ -135,6 +136,7 @@ pub struct libusb_bos_descriptor {
     pub bDescriptorType: u8,
     pub wTotalLength: u16,
     pub bNumDeviceCaps: u8,
+    pub dev_capability: [libusb_bos_dev_capability_descriptor; 0],
 }
 
 #[allow(non_snake_case)]

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -446,6 +446,7 @@ extern "system" {
         removed_cb: Option<libusb_pollfd_removed_cb>,
         user_data: *mut c_void,
     );
+    pub fn libusb_free_pollfds(pollfds: *const *mut libusb_pollfd);
     pub fn libusb_hotplug_register_callback(
         ctx: *mut libusb_context,
         events: c_int,

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -542,7 +542,7 @@ pub unsafe fn libusb_fill_control_setup(
     wIndex: u16,
     wLength: u16,
 ) {
-    let mut setup: *mut libusb_control_setup = buffer as *mut _;
+    let setup: *mut libusb_control_setup = buffer as *mut _;
     (*setup).bmRequestType = bmRequestType;
     (*setup).bRequest = bRequest;
     (*setup).wValue = wValue.to_le();

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -204,6 +204,83 @@ pub struct libusb_pollfd {
     pub events: c_short,
 }
 
+#[repr(C)]
+pub union libusb_init_option__value {
+    pub ival: c_int,
+    pub log_cbval: libusb_log_cb,
+}
+
+#[repr(C)]
+pub enum libusb_option {
+    /// Set the log message verbosity.
+    ///
+    /// This option must be provided an argument of type \ref libusb_log_level.
+    /// The default level is LIBUSB_LOG_LEVEL_NONE, which means no messages are ever
+    /// printed. If you choose to increase the message verbosity level, ensure
+    /// that your application does not close the stderr file descriptor.
+    ///
+    /// You are advised to use level LIBUSB_LOG_LEVEL_WARNING. libusb is conservative
+    /// with its message logging and most of the time, will only log messages that
+    /// explain error conditions and other oddities. This will help you debug
+    /// your software.
+    ///
+    /// If the LIBUSB_DEBUG environment variable was set when libusb was
+    /// initialized, this option does nothing: the message verbosity is fixed
+    /// to the value in the environment variable.
+    ///
+    /// If libusb was compiled without any message logging, this option does
+    /// nothing: you'll never get any messages.
+    ///
+    /// If libusb was compiled with verbose debug message logging, this option
+    /// does nothing: you'll always get messages from all levels.
+    LIBUSB_OPTION_LOG_LEVEL = 0,
+
+    /// Use the UsbDk backend for a specific context, if available.
+    ///
+    /// This option should be set at initialization with libusb_init_context()
+    /// otherwise unspecified behavior may occur.
+    ///
+    /// Only valid on Windows. Ignored on all other platforms.
+    LIBUSB_OPTION_USE_USBDK = 1,
+
+    /// Do not scan for devices. LIBUSB_OPTION_WEAK_AUTHORITY is aliased to this
+    ///
+    /// With this option set, libusb will skip scanning devices in
+    /// libusb_init_context().
+    ///
+    /// Hotplug functionality will also be deactivated.
+    ///
+    /// The option is useful in combination with libusb_wrap_sys_device(),
+    /// which can access a device directly without prior device scanning.
+    ///
+    /// This is typically needed on Android, where access to USB devices
+    /// is limited.
+    ///
+    /// This option should only be used with libusb_init_context()
+    /// otherwise unspecified behavior may occur.
+    ///
+    /// Only valid on Linux. Ignored on all other platforms.
+    LIBUSB_OPTION_NO_DEVICE_DISCOVERY = 2,
+
+    /// Set the context log callback function.
+    ///
+    /// Set the log callback function either on a context or globally. This
+    /// option must be provided an argument of type \ref libusb_log_cb.
+    /// Using this option with a NULL context is equivalent to calling
+    /// libusb_set_log_cb() with mode \ref LIBUSB_LOG_CB_GLOBAL.
+    /// Using it with a non-NULL context is equivalent to calling
+    /// libusb_set_log_cb() with mode \ref LIBUSB_LOG_CB_CONTEXT.
+    LIBUSB_OPTION_LOG_CB = 3,
+
+    LIBUSB_OPTION_MAX = 4,
+}
+
+#[repr(C)]
+pub struct libusb_init_option {
+    pub option: libusb_option,
+    pub value: libusb_init_option__value,
+}
+
 pub type libusb_hotplug_callback_handle = c_int;
 pub type libusb_hotplug_flag = c_int;
 pub type libusb_hotplug_event = c_int;
@@ -230,6 +307,11 @@ extern "system" {
     pub fn libusb_strerror(errcode: c_int) -> *const c_char;
 
     pub fn libusb_init(context: *mut *mut libusb_context) -> c_int;
+    pub fn libusb_init_context(
+        context: *mut *mut libusb_context,
+        options: *mut libusb_init_option,
+        num_options: c_int,
+    ) -> c_int;
     pub fn libusb_exit(context: *mut libusb_context);
     pub fn libusb_set_debug(context: *mut libusb_context, level: c_int);
     pub fn libusb_set_log_cb(context: *mut libusb_context, cb: Option<libusb_log_cb>, mode: c_int);

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -21,6 +21,21 @@ unsafe impl Sync for ConfigDescriptor {}
 unsafe impl Send for ConfigDescriptor {}
 
 impl ConfigDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        unsafe { (*self.descriptor).bLength }
+    }
+
+    /// Returns the total length in bytes of data returned for this configuration: all interfaces and endpoints
+    pub fn total_length(&self) -> u16 {
+        unsafe { (*self.descriptor).wTotalLength }
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        unsafe { (*self.descriptor).bDescriptorType }
+    }
+
     /// Returns the configuration number.
     pub fn number(&self) -> u8 {
         unsafe { (*self.descriptor).bConfigurationValue }

--- a/src/device_descriptor.rs
+++ b/src/device_descriptor.rs
@@ -10,6 +10,16 @@ pub struct DeviceDescriptor {
 }
 
 impl DeviceDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the device's maximum supported USB version.
     pub fn usb_version(&self) -> Version {
         Version::from_bcd(self.descriptor.bcdUSB)

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -2,6 +2,7 @@ use std::{
     fmt::{self, Debug},
     mem,
     ptr::NonNull,
+    sync::Mutex,
     time::Duration,
 };
 
@@ -109,18 +110,18 @@ impl<'a> Iterator for ClaimedInterfacesIter<'a> {
 }
 
 /// A handle to an open USB device.
-#[derive(Eq, PartialEq)]
 pub struct DeviceHandle<T: UsbContext> {
     context: T,
     handle: Option<NonNull<libusb_device_handle>>,
-    interfaces: ClaimedInterfaces,
+    interfaces: Mutex<ClaimedInterfaces>,
 }
 
 impl<T: UsbContext> Drop for DeviceHandle<T> {
     /// Closes the device.
     fn drop(&mut self) {
         unsafe {
-            for iface in self.interfaces.iter() {
+            let interfaces = self.interfaces.lock().unwrap();
+            for iface in interfaces.iter() {
                 libusb_release_interface(self.as_raw(), iface as c_int);
             }
 
@@ -139,10 +140,20 @@ impl<T: UsbContext> Debug for DeviceHandle<T> {
         f.debug_struct("DeviceHandle")
             .field("device", &self.device())
             .field("handle", &self.handle)
-            .field("interfaces", &self.interfaces)
+            .field("interfaces", &*self.interfaces.lock().unwrap())
             .finish()
     }
 }
+
+impl<T: UsbContext + PartialEq> PartialEq for DeviceHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.context == other.context
+            && self.handle == other.handle
+            && *self.interfaces.lock().unwrap() == *other.interfaces.lock().unwrap()
+    }
+}
+
+impl<T: UsbContext + PartialEq> Eq for DeviceHandle<T> {}
 
 impl<T: UsbContext> DeviceHandle<T> {
     /// Get the raw libusb_device_handle pointer, for advanced use in unsafe code.
@@ -164,7 +175,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     ///
     /// Panics if you have any claimed interfaces on this handle.
     pub fn into_raw(mut self) -> *mut libusb_device_handle {
-        assert_eq!(self.interfaces.size(), 0);
+        assert_eq!(self.interfaces.lock().unwrap().size(), 0);
         match self.handle.take() {
             Some(it) => it.as_ptr(),
             _ => unreachable!(),
@@ -197,7 +208,7 @@ impl<T: UsbContext> DeviceHandle<T> {
         DeviceHandle {
             context,
             handle: Some(handle),
-            interfaces: ClaimedInterfaces::new(),
+            interfaces: Mutex::new(ClaimedInterfaces::new()),
         }
     }
 
@@ -210,25 +221,25 @@ impl<T: UsbContext> DeviceHandle<T> {
     }
 
     /// Sets the device's active configuration.
-    pub fn set_active_configuration(&mut self, config: u8) -> crate::Result<()> {
+    pub fn set_active_configuration(&self, config: u8) -> crate::Result<()> {
         try_unsafe!(libusb_set_configuration(self.as_raw(), c_int::from(config)));
         Ok(())
     }
 
     /// Puts the device in an unconfigured state.
-    pub fn unconfigure(&mut self) -> crate::Result<()> {
+    pub fn unconfigure(&self) -> crate::Result<()> {
         try_unsafe!(libusb_set_configuration(self.as_raw(), -1));
         Ok(())
     }
 
     /// Resets the device.
-    pub fn reset(&mut self) -> crate::Result<()> {
+    pub fn reset(&self) -> crate::Result<()> {
         try_unsafe!(libusb_reset_device(self.as_raw()));
         Ok(())
     }
 
     /// Clear the halt/stall condition for an endpoint.
-    pub fn clear_halt(&mut self, endpoint: u8) -> crate::Result<()> {
+    pub fn clear_halt(&self, endpoint: u8) -> crate::Result<()> {
         try_unsafe!(libusb_clear_halt(self.as_raw(), endpoint));
         Ok(())
     }
@@ -247,7 +258,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// Detaches an attached kernel driver from the device.
     ///
     /// This method is not supported on all platforms.
-    pub fn detach_kernel_driver(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn detach_kernel_driver(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_detach_kernel_driver(
             self.as_raw(),
             c_int::from(iface)
@@ -258,7 +269,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// Attaches a kernel driver to the device.
     ///
     /// This method is not supported on all platforms.
-    pub fn attach_kernel_driver(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn attach_kernel_driver(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_attach_kernel_driver(
             self.as_raw(),
             c_int::from(iface)
@@ -275,7 +286,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// On platforms which do not have support, this function will
     /// return `Error::NotSupported`, and rusb will continue as if
     /// this function was never called.
-    pub fn set_auto_detach_kernel_driver(&mut self, auto_detach: bool) -> crate::Result<()> {
+    pub fn set_auto_detach_kernel_driver(&self, auto_detach: bool) -> crate::Result<()> {
         try_unsafe!(libusb_set_auto_detach_kernel_driver(
             self.as_raw(),
             auto_detach.into()
@@ -287,21 +298,21 @@ impl<T: UsbContext> DeviceHandle<T> {
     ///
     /// An interface must be claimed before operating on it. All claimed interfaces are released
     /// when the device handle goes out of scope.
-    pub fn claim_interface(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn claim_interface(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_claim_interface(self.as_raw(), c_int::from(iface)));
-        self.interfaces.insert(iface);
+        self.interfaces.lock().unwrap().insert(iface);
         Ok(())
     }
 
     /// Releases a claimed interface.
-    pub fn release_interface(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn release_interface(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_release_interface(self.as_raw(), c_int::from(iface)));
-        self.interfaces.remove(iface);
+        self.interfaces.lock().unwrap().remove(iface);
         Ok(())
     }
 
     /// Sets an interface's active setting.
-    pub fn set_alternate_setting(&mut self, iface: u8, setting: u8) -> crate::Result<()> {
+    pub fn set_alternate_setting(&self, iface: u8, setting: u8) -> crate::Result<()> {
         try_unsafe!(libusb_set_interface_alt_setting(
             self.as_raw(),
             c_int::from(iface),

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -10,6 +10,16 @@ pub struct EndpointDescriptor<'a> {
 }
 
 impl<'a> EndpointDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the endpoint's address.
     pub fn address(&self) -> u8 {
         self.descriptor.bEndpointAddress

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
 use std::{fmt, result};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use libusb1_sys::constants::*;
 
 /// A result of a function that may return a `Error`.
@@ -7,6 +10,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// Errors returned by the `libusb` library.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// Input/output error.
     Io,

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,10 +1,14 @@
 use libc::c_int;
 use libusb1_sys::constants::*;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Device speeds. Indicates the speed at which a device is operating.
 /// - [libusb_supported_speed](http://libusb.sourceforge.net/api-1.0/group__libusb__dev.html#ga1454797ecc0de4d084c1619c420014f6)
 /// - [USB release versions](https://en.wikipedia.org/wiki/USB#Release_versions)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum Speed {
     /// The operating system doesn't know the device speed.
@@ -41,6 +45,7 @@ pub(crate) fn speed_from_libusb(n: c_int) -> Speed {
 
 /// Transfer and endpoint directions.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Direction {
     /// Direction for read (device to host) transfers.
     In,
@@ -51,6 +56,7 @@ pub enum Direction {
 
 /// An endpoint's transfer type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TransferType {
     /// Control endpoint.
     Control,
@@ -67,6 +73,7 @@ pub enum TransferType {
 
 /// Isochronous synchronization mode.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SyncType {
     /// No synchronisation.
     NoSync,
@@ -83,6 +90,7 @@ pub enum SyncType {
 
 /// Isochronous usage type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UsageType {
     /// Data endpoint.
     Data,
@@ -99,6 +107,7 @@ pub enum UsageType {
 
 /// Types of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RequestType {
     /// Requests that are defined by the USB standard.
     Standard,
@@ -115,6 +124,7 @@ pub enum RequestType {
 
 /// Recipients of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Recipient {
     /// The recipient is a device.
     Device,
@@ -144,6 +154,7 @@ pub enum Recipient {
 /// The intended use case of `Version` is to extract meaning from the version fields in USB
 /// descriptors, such as `bcdUSB` and `bcdDevice` in device descriptors.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version(pub u8, pub u8, pub u8);
 
 impl Version {

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -51,6 +51,16 @@ pub struct InterfaceDescriptor<'a> {
 }
 
 impl<'a> InterfaceDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the interface's number.
     pub fn interface_number(&self) -> u8 {
         self.descriptor.bInterfaceNumber

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -101,11 +101,9 @@ impl<'a> InterfaceDescriptor<'a> {
 
     /// Returns an iterator over the interface's endpoint descriptors.
     pub fn endpoint_descriptors(&self) -> EndpointDescriptors<'a> {
-        let endpoints = unsafe {
-            slice::from_raw_parts(
-                self.descriptor.endpoint,
-                self.descriptor.bNumEndpoints as usize,
-            )
+        let endpoints = match self.descriptor.bNumEndpoints {
+            0 => &[],
+            n => unsafe { slice::from_raw_parts(self.descriptor.endpoint, n as usize) },
         };
 
         EndpointDescriptors {

--- a/src/language.rs
+++ b/src/language.rs
@@ -17,7 +17,7 @@ impl Language {
     /// Returns the language's 16-bit `LANGID`.
     ///
     /// Each language's `LANGID` is defined by the USB forum
-    /// <http://www.usb.org/developers/docs/USB_LANGIDs.pdf>.
+    /// <https://learn.microsoft.com/en-us/windows/win32/intl/language-identifier-constants-and-strings>.
     pub fn lang_id(self) -> u16 {
         self.raw
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use libusb1_sys::constants;
 pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
-    context::{Context, GlobalContext, LogLevel, UsbContext},
+    context::{Context, GlobalContext, LogCallbackMode, LogLevel, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
     device_handle::DeviceHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub use libusb1_sys as ffi;
 pub use libusb1_sys::constants;
 
+#[cfg(unix)]
+pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
     context::{Context, GlobalContext, LogLevel, UsbContext},

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,3 +37,21 @@ enum OptionInner {
     #[cfg_attr(not(windows), allow(dead_code))] // only constructed on Windows
     UseUsbdk,
 }
+
+/// Disable device scanning in `libusb` init.
+///
+/// Hotplug functionality will also be deactivated.
+///
+/// This is a Linux only option and it must be set before any [`Context`]
+/// creation.
+///
+/// The option is useful in combination with [`Context::open_device_with_fd()`],
+/// which can access a device directly without prior device scanning.
+#[cfg(unix)]
+pub fn disable_device_discovery() -> crate::Result<()> {
+    try_unsafe!(libusb1_sys::libusb_set_option(
+        std::ptr::null_mut(),
+        LIBUSB_OPTION_NO_DEVICE_DISCOVERY
+    ));
+    Ok(())
+}


### PR DESCRIPTION
Hey @StephanvanSchaik,

I am opening this PR to ask a few questions regarding your implementation, as the "Issues" tab is not open in this repository. I will close this PR after finding my answers:

I'm trying to understand the working of the `new_bulk_transfer_async` implementation in your [async-v2](https://github.com/StephanvanSchaik/rusb/tree/) branch. 

I have a few questions:

1. Can your rusb_async implementation transfer bulk data asynchronously without waiting for the USB to submit the data to the USB device?
2. If yes, is there any internal queue size limit for pending tasks? What's the maximum queue size? 
   a. And are there any max buffered size restrictions for async data?
3. I have a requirement where I need to read data in a loop, process it in the same order as in the MTP device, and write it to a buffered file. The read should end when the data size is 0. Can this logic be implemented using your rusb_async implementation? Here's a simplified example of what I'm trying to achieve:

```rust
async fn read_and_process_data(usb_handle: &UsbHandle, endpoint: u8) -> Result<(), Error> {
    const QUEUE_SIZE: usize = 5;
    const BUFFER_SIZE: usize = 16384;
    let mut read_queue = Vec::new();

    loop {
        // Fill the queue
        while read_queue.len() < QUEUE_SIZE {
            let buffer = vec![0u8; BUFFER_SIZE].into_boxed_slice();
            let read_future = usb_handle.read_bulk_async(endpoint, buffer, timeout);
            read_queue.push(read_future);
        }

        // Wait for all reads to complete
        let results = futures::future::join_all(read_queue.drain(..)).await;

        // Process results in order
        for result in results {
            let (data, size) = result?;
            if size == 0 {
                return Ok(());  // End of data
            }
            process_data(&data[..size])?;
        }
    }
}
```
4. Are there any potential race conditions to be aware of when using rusb_async, especially when queuing multiple operations?
5. Can we guarantee that the read or write operations to/from the USB device will be executed in the exact order they were submitted? This is crucial for maintaining data integrity in my use case.
6. I checked the examples in your code repository, and it seems they use `await` to fetch data one after another. Wouldn't this make the whole process synchronous, since each `read_bulk_async` call is waiting for the transaction to complete before starting the next one?

I understand it's a lot of questions, but I appreciate your guidance on this. Your insights will be extremely valuable for my implementation.
