### PR TITLE
Question: `Signal: SIGSEGV (signal SIGSEGV: invalid address (fault address: 0x0))` on Linux

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,18 +13,18 @@ jobs:
   check-code:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: true
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
 
-    - name: Install
-      run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libusb-1.0-0-dev
+      - name: Install
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libusb-1.0-0-dev
 
-    - name: Run check and format
-      run: |
-        cargo check --all-targets --examples
-        cargo fmt --check
+      - name: Run check and format
+        run: |
+          cargo check --all-targets --examples
+          cargo fmt --check
 
   build:
     needs: [check-code]
@@ -34,12 +34,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            apt: 'libusb-1.0-0-dev'
+            apt: "libusb-1.0-0-dev"
             experimental: false
             features: ""
 
           - os: ubuntu-latest
-            apt: 'libudev-dev'
+            apt: "libudev-dev"
             experimental: false
             features: ""
 
@@ -67,7 +67,7 @@ jobs:
             features: ""
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 0.9.4
+
+* bLength, bDescriptorType and wTotalLength to descriptors [#185]
+* Use &self reference for all DeviceHandle methods [#186]
+* fix: panic when trying to iterate over an interface with zero endpoints [#195]
+* Log callback API added [#194]
+* Bump libusb1-sys 0.7.0 [#205]
+
+[#185]: https://github.com/a1ien/rusb/pull/185
+[#186]: https://github.com/a1ien/rusb/pull/186
+[#195]: https://github.com/a1ien/rusb/pull/195
+[#194]: https://github.com/a1ien/rusb/pull/194
+[#205]: https://github.com/a1ien/rusb/pull/205
+
 ## 0.9.3
 * impl serde::{Serialize, Deserialize} for public enums [#167]
 * Update deprecated doc link about language identifiers [#165]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changes
 
-## unreleased
+## 0.9.2
+* Random corrections around the code [#127]
+* examples: list_devices: Add vendor and product name [#128]
+* examples: read_devices: Improve usage [#125]
+* context: create rusb `Context` from existing `libusb_context` [#135]
+* `new` now uses `from_raw` [#135]
+* Fix stack use after scope in tests [#138]
+* Fix United Kingdom misspelling in languages docs [#137]
+* fields.rs: Make request_type function a const fn [#142]
+* Increase endpoint descriptor's lifetime [#149]
+* Fix timeout documentation [#151]
+
+[#127]: https://github.com/a1ien/rusb/pull/116
+[#128]: https://github.com/a1ien/rusb/pull/116
+[#125]: https://github.com/a1ien/rusb/pull/116
+[#135]: https://github.com/a1ien/rusb/pull/116
+[#138]: https://github.com/a1ien/rusb/pull/116
+[#137]: https://github.com/a1ien/rusb/pull/116
+[#142]: https://github.com/a1ien/rusb/pull/116
+[#149]: https://github.com/a1ien/rusb/pull/116
+[#151]: https://github.com/a1ien/rusb/pull/116
+
+## 0.9.1
 * impl Ord and PartialOrd for Version [#116]
 
 [#116]: https://github.com/a1ien/rusb/pull/116

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@
 * Increase endpoint descriptor's lifetime [#149]
 * Fix timeout documentation [#151]
 
-[#127]: https://github.com/a1ien/rusb/pull/116
-[#128]: https://github.com/a1ien/rusb/pull/116
-[#125]: https://github.com/a1ien/rusb/pull/116
-[#135]: https://github.com/a1ien/rusb/pull/116
-[#138]: https://github.com/a1ien/rusb/pull/116
-[#137]: https://github.com/a1ien/rusb/pull/116
-[#142]: https://github.com/a1ien/rusb/pull/116
-[#149]: https://github.com/a1ien/rusb/pull/116
-[#151]: https://github.com/a1ien/rusb/pull/116
+[#127]: https://github.com/a1ien/rusb/pull/127
+[#128]: https://github.com/a1ien/rusb/pull/128
+[#125]: https://github.com/a1ien/rusb/pull/125
+[#135]: https://github.com/a1ien/rusb/pull/135
+[#138]: https://github.com/a1ien/rusb/pull/135
+[#137]: https://github.com/a1ien/rusb/pull/137
+[#142]: https://github.com/a1ien/rusb/pull/142
+[#149]: https://github.com/a1ien/rusb/pull/149
+[#151]: https://github.com/a1ien/rusb/pull/151
 
 ## 0.9.1
 * impl Ord and PartialOrd for Version [#116]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 0.9.3
+* impl serde::{Serialize, Deserialize} for public enums [#167]
+* Update deprecated doc link about language identifiers [#165]
+* Fix changelog URLs for 0.9.2 [#164]
+
+
+[#167]: https://github.com/a1ien/rusb/pull/167
+[#165]: https://github.com/a1ien/rusb/pull/165
+[#164]: https://github.com/a1ien/rusb/pull/164
+
 ## 0.9.2
 * Random corrections around the code [#127]
 * examples: list_devices: Add vendor and product name [#128]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "a1ien/rusb" }
 vendored = [ "libusb1-sys/vendored" ]
 
 [workspace]
-members = ["libusb1-sys"]
+members = ["libusb1-sys", "rusb-async"]
 
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
-libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
+libusb1-sys = { path = "libusb1-sys", version = "0.6.4" }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"
@@ -21,7 +21,7 @@ vendored = [ "libusb1-sys/vendored" ]
 members = ["libusb1-sys"]
 
 [dependencies]
-libusb1-sys = { path = "libusb1-sys", version = "0.6.4" }
+libusb1-sys = { path = "libusb1-sys", version = "0.7" }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusb"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>", "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "Rust library for accessing USB devices."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = ["libusb1-sys"]
 [dependencies]
 libusb1-sys = { path = "libusb1-sys", version = "0.6.0" }
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ libc = "0.2"
 
 [dev-dependencies]
 regex = "1"
-usb-ids = "0.2.2"
+usb-ids = "1.2023.0"

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -94,6 +94,8 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
         };
 
     println!("Device Descriptor:");
+    println!("  bLength              {:3}", device_desc.length());
+    println!("  bDescriptorType      {:3}", device_desc.descriptor_type());
     println!(
         "  bcdUSB             {:2}.{}{}",
         device_desc.usb_version().major(),
@@ -147,6 +149,12 @@ fn print_device<T: UsbContext>(device_desc: &DeviceDescriptor, handle: &mut Opti
 
 fn print_config<T: UsbContext>(config_desc: &ConfigDescriptor, handle: &mut Option<UsbDevice<T>>) {
     println!("  Config Descriptor:");
+    println!("    bLength              {:3}", config_desc.length());
+    println!(
+        "    bDescriptorType      {:3}",
+        config_desc.descriptor_type()
+    );
+    println!("    wTotalLength      {:#06x}", config_desc.total_length());
     println!(
         "    bNumInterfaces       {:3}",
         config_desc.num_interfaces()
@@ -177,6 +185,11 @@ fn print_interface<T: UsbContext>(
     handle: &mut Option<UsbDevice<T>>,
 ) {
     println!("    Interface Descriptor:");
+    println!("      bLength              {:3}", interface_desc.length());
+    println!(
+        "      bDescriptorType      {:3}",
+        interface_desc.descriptor_type()
+    );
     println!(
         "      bInterfaceNumber     {:3}",
         interface_desc.interface_number()
@@ -219,6 +232,11 @@ fn print_interface<T: UsbContext>(
 
 fn print_endpoint(endpoint_desc: &EndpointDescriptor) {
     println!("      Endpoint Descriptor:");
+    println!("        bLength              {:3}", endpoint_desc.length());
+    println!(
+        "        bDescriptorType      {:3}",
+        endpoint_desc.descriptor_type()
+    );
     println!(
         "        bEndpointAddress    {:#04x} EP {} {:?}",
         endpoint_desc.address(),

--- a/libusb1-sys/CHANGELOG.md
+++ b/libusb1-sys/CHANGELOG.md
@@ -1,6 +1,41 @@
 # Changes
 
-## unreleased
+## 0.7.0
+
+* fix: Add missing fields to libusb_bos_descriptor and libusb_bos_dev_capability_descriptor [#161]
+* Bump libusb to 1.0.27 [#201]
+* Remove unneeded mut [#204]
+
+[#161]: https://github.com/a1ien/rusb/pull/161
+[#201]: https://github.com/a1ien/rusb/pull/201
+[#204]: https://github.com/a1ien/rusb/pull/204
+
+## 0.6.5
+* Support pkg_config for MSVC. [#191]
+* Fix package detection and build when cross-compiling from MSVC to GNU [#180]
+* libusb_set_iso_packet_lengths panics on debug builds in newest nightly (2024-03-27) [#199]
+* Added libusb_free_pollfds() in the available FFI methods. [#203]
+
+[#191]: https://github.com/a1ien/rusb/pull/191
+[#180]: https://github.com/a1ien/rusb/pull/180
+[#199]: https://github.com/a1ien/rusb/pull/199
+[#203]: https://github.com/a1ien/rusb/pull/203
+
+## 0.6.3-0.6.4
+* Patch for macOS Big Sur and newer allowing to link statically [#133]
+* Add libudev include paths as specified by pkg-config [#140]
+
+[#133]: https://github.com/a1ien/rusb/pull/133
+[#140]: https://github.com/a1ien/rusb/pull/140
+
+
+## 0.6.2
+* Rename compiled library when vendored libusb is used [#130]
+
+[#130]: https://github.com/a1ien/rusb/pull/130
+
+## 0.6.1
+* Add LIBUSB_OPTION_NO_DEVICE_DISCOVERY constant
 * Bump vendored libusb version from 1.0.24 to 1.0.25 [#119]
 
 [#119]: https://github.com/a1ien/rusb/pull/119

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -39,7 +39,7 @@ vendored = []
 [dependencies]
 libc = "0.2"
 
-[target.'cfg(target_env = "msvc")'.build-dependencies]
+[target.'cfg(target_os = "windows")'.build-dependencies]
 vcpkg = "0.2"
 
 [build-dependencies]

--- a/libusb1-sys/Cargo.toml
+++ b/libusb1-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libusb1-sys"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>",
             "Ilya Averyanov <a1ien.n3t@gmail.com>"]
 description = "FFI bindings for libusb."

--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -24,8 +24,12 @@ fn find_libusb_pkg(_statik: bool) -> bool {
     match vcpkg::Config::new().find_package("libusb") {
         Ok(_) => true,
         Err(e) => {
-            println!("Can't find libusb pkg: {:?}", e);
-            false
+            if pkg_config::probe_library("libusb-1.0").is_ok() {
+                true
+            } else {
+                println!("Can't find libusb pkg: {:?}", e);
+                false
+            }
         }
     }
 }

--- a/libusb1-sys/build.rs
+++ b/libusb1-sys/build.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-static VERSION: &str = "1.0.24";
+static VERSION: &str = "1.0.27";
 
 fn link(name: &str, bundled: bool) {
     use std::env::var;

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -658,10 +658,7 @@ pub unsafe fn libusb_fill_iso_transfer(
 #[inline]
 pub unsafe fn libusb_set_iso_packet_lengths(transfer: *mut libusb_transfer, length: c_uint) {
     for i in 0..(*transfer).num_iso_packets {
-        (*transfer)
-            .iso_packet_desc
-            .get_unchecked_mut(i as usize)
-            .length = length;
+        (*(*transfer).iso_packet_desc.as_mut_ptr().add(i as usize)).length = length;
     }
 }
 
@@ -675,10 +672,7 @@ pub unsafe fn libusb_get_iso_packet_buffer(
     }
     let mut offset = 0;
     for i in 0..packet {
-        offset += (*transfer)
-            .iso_packet_desc
-            .get_unchecked_mut(i as usize)
-            .length;
+        offset += (*(*transfer).iso_packet_desc.as_mut_ptr().add(i as usize)).length;
     }
 
     (*transfer).buffer.add(offset as usize)
@@ -695,5 +689,5 @@ pub unsafe fn libusb_get_iso_packet_buffer_simple(
 
     (*transfer)
         .buffer
-        .add(((*transfer).iso_packet_desc.get_unchecked_mut(0).length * packet) as usize)
+        .add(((*(*transfer).iso_packet_desc.as_mut_ptr().add(0)).length * packet) as usize)
 }

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -126,6 +126,7 @@ pub struct libusb_bos_dev_capability_descriptor {
     pub bLength: u8,
     pub bDescriptorType: u8,
     pub bDevCapabilityType: u8,
+    pub dev_capability_data: [u8; 0],
 }
 
 #[allow(non_snake_case)]
@@ -135,6 +136,7 @@ pub struct libusb_bos_descriptor {
     pub bDescriptorType: u8,
     pub wTotalLength: u16,
     pub bNumDeviceCaps: u8,
+    pub dev_capability: [libusb_bos_dev_capability_descriptor; 0],
 }
 
 #[allow(non_snake_case)]

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -446,6 +446,7 @@ extern "system" {
         removed_cb: Option<libusb_pollfd_removed_cb>,
         user_data: *mut c_void,
     );
+    pub fn libusb_free_pollfds(pollfds: *const *mut libusb_pollfd);
     pub fn libusb_hotplug_register_callback(
         ctx: *mut libusb_context,
         events: c_int,

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -542,7 +542,7 @@ pub unsafe fn libusb_fill_control_setup(
     wIndex: u16,
     wLength: u16,
 ) {
-    let mut setup: *mut libusb_control_setup = buffer as *mut _;
+    let setup: *mut libusb_control_setup = buffer as *mut _;
     (*setup).bmRequestType = bmRequestType;
     (*setup).bRequest = bRequest;
     (*setup).wValue = wValue.to_le();

--- a/libusb1-sys/src/lib.rs
+++ b/libusb1-sys/src/lib.rs
@@ -204,6 +204,83 @@ pub struct libusb_pollfd {
     pub events: c_short,
 }
 
+#[repr(C)]
+pub union libusb_init_option__value {
+    pub ival: c_int,
+    pub log_cbval: libusb_log_cb,
+}
+
+#[repr(C)]
+pub enum libusb_option {
+    /// Set the log message verbosity.
+    ///
+    /// This option must be provided an argument of type \ref libusb_log_level.
+    /// The default level is LIBUSB_LOG_LEVEL_NONE, which means no messages are ever
+    /// printed. If you choose to increase the message verbosity level, ensure
+    /// that your application does not close the stderr file descriptor.
+    ///
+    /// You are advised to use level LIBUSB_LOG_LEVEL_WARNING. libusb is conservative
+    /// with its message logging and most of the time, will only log messages that
+    /// explain error conditions and other oddities. This will help you debug
+    /// your software.
+    ///
+    /// If the LIBUSB_DEBUG environment variable was set when libusb was
+    /// initialized, this option does nothing: the message verbosity is fixed
+    /// to the value in the environment variable.
+    ///
+    /// If libusb was compiled without any message logging, this option does
+    /// nothing: you'll never get any messages.
+    ///
+    /// If libusb was compiled with verbose debug message logging, this option
+    /// does nothing: you'll always get messages from all levels.
+    LIBUSB_OPTION_LOG_LEVEL = 0,
+
+    /// Use the UsbDk backend for a specific context, if available.
+    ///
+    /// This option should be set at initialization with libusb_init_context()
+    /// otherwise unspecified behavior may occur.
+    ///
+    /// Only valid on Windows. Ignored on all other platforms.
+    LIBUSB_OPTION_USE_USBDK = 1,
+
+    /// Do not scan for devices. LIBUSB_OPTION_WEAK_AUTHORITY is aliased to this
+    ///
+    /// With this option set, libusb will skip scanning devices in
+    /// libusb_init_context().
+    ///
+    /// Hotplug functionality will also be deactivated.
+    ///
+    /// The option is useful in combination with libusb_wrap_sys_device(),
+    /// which can access a device directly without prior device scanning.
+    ///
+    /// This is typically needed on Android, where access to USB devices
+    /// is limited.
+    ///
+    /// This option should only be used with libusb_init_context()
+    /// otherwise unspecified behavior may occur.
+    ///
+    /// Only valid on Linux. Ignored on all other platforms.
+    LIBUSB_OPTION_NO_DEVICE_DISCOVERY = 2,
+
+    /// Set the context log callback function.
+    ///
+    /// Set the log callback function either on a context or globally. This
+    /// option must be provided an argument of type \ref libusb_log_cb.
+    /// Using this option with a NULL context is equivalent to calling
+    /// libusb_set_log_cb() with mode \ref LIBUSB_LOG_CB_GLOBAL.
+    /// Using it with a non-NULL context is equivalent to calling
+    /// libusb_set_log_cb() with mode \ref LIBUSB_LOG_CB_CONTEXT.
+    LIBUSB_OPTION_LOG_CB = 3,
+
+    LIBUSB_OPTION_MAX = 4,
+}
+
+#[repr(C)]
+pub struct libusb_init_option {
+    pub option: libusb_option,
+    pub value: libusb_init_option__value,
+}
+
 pub type libusb_hotplug_callback_handle = c_int;
 pub type libusb_hotplug_flag = c_int;
 pub type libusb_hotplug_event = c_int;
@@ -230,6 +307,11 @@ extern "system" {
     pub fn libusb_strerror(errcode: c_int) -> *const c_char;
 
     pub fn libusb_init(context: *mut *mut libusb_context) -> c_int;
+    pub fn libusb_init_context(
+        context: *mut *mut libusb_context,
+        options: *mut libusb_init_option,
+        num_options: c_int,
+    ) -> c_int;
     pub fn libusb_exit(context: *mut libusb_context);
     pub fn libusb_set_debug(context: *mut libusb_context, level: c_int);
     pub fn libusb_set_log_cb(context: *mut libusb_context, cb: Option<libusb_log_cb>, mode: c_int);

--- a/rusb-async/Cargo.toml
+++ b/rusb-async/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rusb-async"
+version = "0.0.1-alpha-2"
+edition = "2021"
+authors = [
+"Ilya Averyanov <a1ien.n3t@gmail.com>",
+"Ryan Butler <thebutlah@gmail.com>",
+"Kevin Mehall <km@kevinmehall.net>",
+]
+
+description = "Rust library for accessing USB devices."
+license = "MIT"
+homepage = "https://github.com/a1ien/rusb"
+repository = "https://github.com/a1ien/rusb.git"
+keywords = ["usb", "libusb", "async"]
+
+[features]
+vendored = [ "rusb/vendored" ]
+
+[dependencies]
+async-trait = "0.1"
+rusb = { path = "..", version = "0.9.1" }
+libc = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/rusb-async/examples/read_async.rs
+++ b/rusb-async/examples/read_async.rs
@@ -35,7 +35,7 @@ async fn main() {
     );
 
     let timeout = Duration::from_secs(10);
-    let mut buffer = Vec::with_capacity(BUF_SIZE);
+    let mut buffer = vec![0u8; BUF_SIZE].into_boxed_slice();
 
     loop {
         let (bytes, n) = device

--- a/rusb-async/examples/read_async.rs
+++ b/rusb-async/examples/read_async.rs
@@ -1,0 +1,50 @@
+use rusb::UsbContext as _;
+use rusb_async::{Context, DeviceHandleExt as _};
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+const BUF_SIZE: usize = 64;
+
+fn convert_argument(input: &str) -> u16 {
+    if input.starts_with("0x") {
+        return u16::from_str_radix(input.trim_start_matches("0x"), 16).unwrap();
+    }
+    u16::from_str_radix(input, 10)
+        .expect("Invalid input, be sure to add `0x` for hexadecimal values.")
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 4 {
+        eprintln!("Usage: read_async <base-10/0xbase-16> <base-10/0xbase-16> <endpoint>");
+        return;
+    }
+
+    let vid = convert_argument(args[1].as_ref());
+    let pid = convert_argument(args[2].as_ref());
+    let endpoint: u8 = FromStr::from_str(args[3].as_ref()).unwrap();
+
+    let ctx = Context::new().expect("Could not initialize libusb");
+    let device = Arc::new(
+        ctx.open_device_with_vid_pid(vid, pid)
+            .expect("Could not find device"),
+    );
+
+    let timeout = Duration::from_secs(10);
+    let mut buffer = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        let (bytes, n) = device
+            .read_bulk_async(endpoint, buffer, timeout)
+            .await
+            .expect("Failed to submit transfer");
+
+        println!("Got data: {} {:?}", n, &bytes[..n]);
+
+        buffer = bytes;
+    }
+}

--- a/rusb-async/examples/read_async.rs
+++ b/rusb-async/examples/read_async.rs
@@ -1,17 +1,24 @@
 use rusb::UsbContext as _;
 use rusb_async::{Context, DeviceHandleExt as _};
 
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
 const BUF_SIZE: usize = 64;
 
-fn convert_argument(input: &str) -> u16 {
+fn convert_argument_u16(input: &str) -> u16 {
     if input.starts_with("0x") {
         return u16::from_str_radix(input.trim_start_matches("0x"), 16).unwrap();
     }
     u16::from_str_radix(input, 10)
+        .expect("Invalid input, be sure to add `0x` for hexadecimal values.")
+}
+
+fn convert_argument_u8(input: &str) -> u8 {
+    if input.starts_with("0x") {
+        return u8::from_str_radix(input.trim_start_matches("0x"), 16).unwrap();
+    }
+    u8::from_str_radix(input, 10)
         .expect("Invalid input, be sure to add `0x` for hexadecimal values.")
 }
 
@@ -24,9 +31,9 @@ async fn main() {
         return;
     }
 
-    let vid = convert_argument(args[1].as_ref());
-    let pid = convert_argument(args[2].as_ref());
-    let endpoint: u8 = FromStr::from_str(args[3].as_ref()).unwrap();
+    let vid = convert_argument_u16(args[1].as_ref());
+    let pid = convert_argument_u16(args[2].as_ref());
+    let endpoint = convert_argument_u8(args[3].as_ref());
 
     let ctx = Context::new().expect("Could not initialize libusb");
     let device = Arc::new(

--- a/rusb-async/src/context.rs
+++ b/rusb-async/src/context.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use rusb::{Error, UsbContext};
 use rusb::ffi::*;
+use rusb::{Error, UsbContext};
 
 struct EventThread {
     thread: Option<JoinHandle<Result<(), Error>>>,
@@ -36,9 +36,7 @@ impl Drop for EventThread {
     fn drop(&mut self) {
         self.should_quit.store(true, Ordering::SeqCst);
 
-        let _ = self.thread
-            .take()
-            .map(|thread| thread.join());
+        let _ = self.thread.take().map(|thread| thread.join());
     }
 }
 

--- a/rusb-async/src/context.rs
+++ b/rusb-async/src/context.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use rusb::{Error, UsbContext};
+use rusb::ffi::*;
+
+struct EventThread {
+    thread: Option<JoinHandle<Result<(), Error>>>,
+    should_quit: Arc<AtomicBool>,
+}
+
+impl EventThread {
+    fn new(context: &mut rusb::Context) -> Self {
+        let thread_context = context.clone();
+        let tx = Arc::new(AtomicBool::new(false));
+        let rx = tx.clone();
+
+        let thread = std::thread::spawn(move || -> Result<(), Error> {
+            while !rx.load(Ordering::SeqCst) {
+                thread_context.handle_events(Some(Duration::from_millis(0)))?;
+            }
+
+            Ok(())
+        });
+
+        Self {
+            thread: Some(thread),
+            should_quit: tx,
+        }
+    }
+}
+
+impl Drop for EventThread {
+    fn drop(&mut self) {
+        self.should_quit.store(true, Ordering::SeqCst);
+
+        let _ = self.thread
+            .take()
+            .map(|thread| thread.join());
+    }
+}
+
+/// A `libusb` context with a dedicated thread to handle events in the background.
+#[derive(Clone)]
+pub struct Context {
+    inner: rusb::Context,
+    _thread: Arc<EventThread>,
+}
+
+impl Context {
+    /// Opens a new `libusb` context and spawns a thread to handle events in the background for
+    /// that context.
+    pub fn new() -> Result<Self, Error> {
+        let mut inner = rusb::Context::new()?;
+        let thread = EventThread::new(&mut inner);
+
+        Ok(Self {
+            inner,
+            _thread: Arc::new(thread),
+        })
+    }
+}
+
+impl UsbContext for Context {
+    fn as_raw(&self) -> *mut libusb_context {
+        self.inner.as_raw()
+    }
+}

--- a/rusb-async/src/context.rs
+++ b/rusb-async/src/context.rs
@@ -59,6 +59,15 @@ impl Context {
             _thread: Arc::new(thread),
         })
     }
+
+    pub fn from_context(ctx: &mut rusb::Context) -> Result<Self, Error> {
+        let thread = EventThread::new(ctx);
+
+        Ok(Self {
+            inner,
+            _thread: Arc::new(thread),
+        })
+    }
 }
 
 impl UsbContext for Context {

--- a/rusb-async/src/context.rs
+++ b/rusb-async/src/context.rs
@@ -59,15 +59,6 @@ impl Context {
             _thread: Arc::new(thread),
         })
     }
-
-    pub fn from_context(ctx: &mut rusb::Context) -> Result<Self, Error> {
-        let thread = EventThread::new(ctx);
-
-        Ok(Self {
-            inner,
-            _thread: Arc::new(thread),
-        })
-    }
 }
 
 impl UsbContext for Context {

--- a/rusb-async/src/lib.rs
+++ b/rusb-async/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod context;
+pub mod transfer;
+
+pub use crate::context::Context;
+pub use crate::transfer::{CancellationToken, DeviceHandleExt, Transfer};

--- a/rusb-async/src/transfer.rs
+++ b/rusb-async/src/transfer.rs
@@ -167,12 +167,7 @@ impl<T: UsbContext> Future for Transfer<T> {
         //
         // In addition, `Future::poll()` should not be called a second time after it returns
         // `Poll::Ready`. Thus, it is safe to panic.
-        let buffer = self
-            .buffer
-            .lock()
-            .unwrap()
-            .take()
-            .unwrap();
+        let buffer = self.buffer.lock().unwrap().take().unwrap();
 
         // The transfer completed.
         if inner.status == LIBUSB_TRANSFER_COMPLETED {

--- a/rusb-async/src/transfer.rs
+++ b/rusb-async/src/transfer.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use libc::{c_int, c_uint};
-use rusb::{DeviceHandle, Error, UsbContext};
 use rusb::constants::*;
 use rusb::ffi::*;
+use rusb::{DeviceHandle, Error, UsbContext};
 
 const LIBUSB_TRANSFER_ACTIVE: c_int = -1;
 
@@ -72,9 +72,7 @@ impl<T: UsbContext> Drop for InnerTransfer<T> {
     }
 }
 
-extern "system" fn transfer_finished<T: UsbContext>(
-    transfer_ptr: *mut libusb_transfer,
-) {
+extern "system" fn transfer_finished<T: UsbContext>(transfer_ptr: *mut libusb_transfer) {
     if transfer_ptr.is_null() {
         return;
     }
@@ -169,7 +167,8 @@ impl<T: UsbContext> Future for Transfer<T> {
         //
         // In addition, `Future::poll()` should not be called a second time after it returns
         // `Poll::Ready`. Thus, it is safe to panic.
-        let buffer = self.buffer
+        let buffer = self
+            .buffer
             .lock()
             .unwrap()
             .take()
@@ -350,14 +349,7 @@ impl<T: UsbContext> Transfer<T> {
 
             // SAFETY: buffer has at least LIBUSB_CONTROL_SETUP_SIZE bytes and is a valid pointer.
             unsafe {
-                libusb_fill_control_setup(
-                    buffer,
-                    request_type,
-                    request,
-                    value,
-                    index,
-                    max_size
-                );
+                libusb_fill_control_setup(buffer, request_type, request, value, index, max_size);
             }
 
             // SAFETY: transfer_ptr, device.as_ptr(), buffer, state_ptr are all valid. This is the
@@ -741,12 +733,7 @@ impl<T: UsbContext> DeviceHandleExt for DeviceHandle<T> {
             return Err((data, Error::InvalidParam));
         }
 
-        let transfer = Transfer::new_bulk_transfer(
-            self,
-            endpoint,
-            data,
-            timeout,
-        )?;
+        let transfer = Transfer::new_bulk_transfer(self, endpoint, data, timeout)?;
 
         Ok(transfer.await?)
     }
@@ -787,12 +774,7 @@ impl<T: UsbContext> DeviceHandleExt for DeviceHandle<T> {
             return Err((data, Error::InvalidParam));
         }
 
-        let transfer = Transfer::new_interrupt_transfer(
-            self,
-            endpoint,
-            data,
-            timeout,
-        )?;
+        let transfer = Transfer::new_interrupt_transfer(self, endpoint, data, timeout)?;
 
         Ok(transfer.await?)
     }
@@ -807,12 +789,7 @@ impl<T: UsbContext> DeviceHandleExt for DeviceHandle<T> {
             return Err((data, Error::InvalidParam));
         }
 
-        let transfer = Transfer::new_bulk_transfer(
-            self,
-            endpoint,
-            data,
-            timeout,
-        )?;
+        let transfer = Transfer::new_bulk_transfer(self, endpoint, data, timeout)?;
 
         Ok(transfer.await?)
     }
@@ -853,12 +830,7 @@ impl<T: UsbContext> DeviceHandleExt for DeviceHandle<T> {
             return Err((data, Error::InvalidParam));
         }
 
-        let transfer = Transfer::new_interrupt_transfer(
-            self,
-            endpoint,
-            data,
-            timeout,
-        )?;
+        let transfer = Transfer::new_interrupt_transfer(self, endpoint, data, timeout)?;
 
         Ok(transfer.await?)
     }

--- a/rusb-async/src/transfer.rs
+++ b/rusb-async/src/transfer.rs
@@ -1,0 +1,865 @@
+use std::convert::TryInto;
+use std::ffi::c_void;
+use std::future::Future;
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use libc::{c_int, c_uint};
+use rusb::{DeviceHandle, Error, UsbContext};
+use rusb::constants::*;
+use rusb::ffi::*;
+
+const LIBUSB_TRANSFER_ACTIVE: c_int = -1;
+
+fn check_transfer_error(status: c_int) -> Result<(), Error> {
+    if status < 0 {
+        Err(match status {
+            LIBUSB_ERROR_NO_DEVICE => Error::NoDevice,
+            LIBUSB_ERROR_BUSY => Error::Busy,
+            LIBUSB_ERROR_NOT_SUPPORTED => Error::NotSupported,
+            LIBUSB_ERROR_INVALID_PARAM => Error::InvalidParam,
+            _ => Error::Other,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+struct WrappedTransfer(NonNull<libusb_transfer>);
+
+// SAFETY: only used behind an `Arc<Mutex<T>>`.
+unsafe impl Send for WrappedTransfer {}
+
+struct InnerTransfer<T: UsbContext> {
+    transfer: WrappedTransfer,
+    _context: T,
+    status: c_int,
+    actual_length: c_int,
+    waker: Option<Waker>,
+}
+
+impl<T: UsbContext> InnerTransfer<T> {
+    fn new(context: T) -> Result<Self, Error> {
+        let transfer = unsafe { libusb_alloc_transfer(0) };
+
+        if transfer.is_null() {
+            return Err(Error::NoMem);
+        }
+
+        Ok(Self {
+            // SAFETY: transfer is not NULL.
+            transfer: unsafe { WrappedTransfer(NonNull::new_unchecked(transfer)) },
+            _context: context,
+            status: LIBUSB_TRANSFER_ACTIVE,
+            actual_length: -1,
+            waker: None,
+        })
+    }
+
+    fn as_ptr(&mut self) -> *mut libusb_transfer {
+        self.transfer.0.as_ptr()
+    }
+}
+
+impl<T: UsbContext> Drop for InnerTransfer<T> {
+    fn drop(&mut self) {
+        // SAFETY: transfer points to a valid libusb_transfer struct.
+        unsafe { libusb_free_transfer(self.transfer.0.as_ptr()) };
+    }
+}
+
+extern "system" fn transfer_finished<T: UsbContext>(
+    transfer_ptr: *mut libusb_transfer,
+) {
+    if transfer_ptr.is_null() {
+        return;
+    }
+
+    // SAFETY: transfer_ptr is not NULL.
+    let transfer: &mut libusb_transfer = unsafe { &mut *transfer_ptr };
+    let user_data = transfer.user_data;
+
+    if user_data.is_null() {
+        return;
+    }
+
+    // SAFETY: user_data is not NULL and the only user always passes a valid `Arc<Mutex<InnerTransfer<T>>>`.
+    let inner = unsafe { Arc::from_raw(user_data as *mut Mutex<InnerTransfer<T>>) };
+    let mut inner = inner.lock().unwrap();
+
+    inner.status = transfer.status;
+    inner.actual_length = transfer.actual_length;
+
+    if let Some(waker) = inner.waker.take() {
+        waker.wake()
+    }
+}
+
+/// Represents a cancellation token for the [`Transfer`]. This allows the user to cancel the USB
+/// transfer while it is still pending.
+#[derive(Clone)]
+pub struct CancellationToken<T: UsbContext> {
+    inner: Arc<Mutex<InnerTransfer<T>>>,
+}
+
+impl<T: UsbContext> CancellationToken<T> {
+    /// Asynchronously cancels the pending USB transfer. This function returns immediately, but
+    /// this does not indicate that the cancellation is complete. Instead this will unblock the
+    /// task awaiting the [`Transfer`] future and cause it to return [`Error::Interrupted`].
+    pub fn cancel(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        let ptr = inner.as_ptr();
+
+        if inner.status == LIBUSB_TRANSFER_ACTIVE {
+            // SAFETY: the transfer is guarded by `Arc<Mutex<T>>` and we only cancel the transfer
+            // if it is still active.
+            unsafe {
+                libusb_cancel_transfer(ptr);
+            }
+        }
+    }
+}
+
+/// Represents a submitted USB transfer that can be polled until completion, in which case it will
+/// return the ownership of the associated buffer. In the transfer got cancelled, this returns
+/// [`Error::Interrupted`].
+pub struct Transfer<T: UsbContext> {
+    inner: Arc<Mutex<InnerTransfer<T>>>,
+    _context: T,
+    buffer: Arc<Mutex<Option<Pin<Box<[u8]>>>>>,
+}
+
+impl<T: UsbContext> Drop for Transfer<T> {
+    fn drop(&mut self) {
+        let mut inner = self.inner.lock().unwrap();
+        let ptr = inner.as_ptr();
+
+        inner.waker = None;
+
+        if inner.status == LIBUSB_TRANSFER_ACTIVE {
+            // SAFETY: the transfer is guarded by `Arc<Mutex<T>>` and we only cancel the transfer
+            // if it is still active.
+            unsafe {
+                libusb_cancel_transfer(ptr);
+            }
+        }
+    }
+}
+
+impl<T: UsbContext> Future for Transfer<T> {
+    type Output = Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.inner.lock().unwrap();
+
+        // The transfer has not been completed, cancelled or errored out. Clone the waker and
+        // return that the transfer is still pending.
+        if inner.status == LIBUSB_TRANSFER_ACTIVE {
+            inner.waker = Some(ctx.waker().clone());
+
+            return Poll::Pending;
+        }
+
+        // At this point it is safe to claim ownership of the buffer since the transfer_finished
+        // callback has been called as the transfer has been completed, cancelled or errored out.
+        //
+        // In addition, `Future::poll()` should not be called a second time after it returns
+        // `Poll::Ready`. Thus, it is safe to panic.
+        let buffer = self.buffer
+            .lock()
+            .unwrap()
+            .take()
+            .map(|buffer| Pin::<Box<[u8]>>::into_inner(buffer).into_vec())
+            .unwrap();
+
+        // The transfer completed.
+        if inner.status == LIBUSB_TRANSFER_COMPLETED {
+            return Poll::Ready(Ok((buffer, inner.actual_length as usize)));
+        }
+
+        // The transfer has either been cancelled or errored out.
+        let e = match inner.status {
+            LIBUSB_TRANSFER_TIMED_OUT => Error::Timeout,
+            LIBUSB_TRANSFER_CANCELLED => Error::Interrupted,
+            _ => Error::Other,
+        };
+
+        return Poll::Ready(Err((buffer, e)));
+    }
+}
+
+impl<T: UsbContext> Transfer<T> {
+    /// Constructs a new bulk transfer to transfer data to/from the bulk endpoint with the address
+    /// given by the `endpoint` parameter and fills `data` with any data received from the endpoint
+    /// or writes the contents of `data` to the endpoint depending on the direction of the
+    /// endpoint. The transfer will claim ownership of `data` until the request completes, gets
+    /// cancelled or errors out, upon which the ownership of `data` is given back to the task
+    /// awaiting this transfer.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the endpoint for readable endpoints. Otherwise for writeable endpoints, `n`
+    /// bytes of `data` were written to the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were transferred.
+    ///
+    /// The errors returned by polling this transfer include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an output endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    pub fn new_bulk_transfer(
+        device: &DeviceHandle<T>,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<Self, (Vec<u8>, Error)> {
+        let context = device.context().clone();
+        let device = unsafe { NonNull::new_unchecked(device.as_raw()) };
+
+        let max_size = data.len() as i32;
+        let timeout = timeout.as_millis() as c_uint;
+
+        let mut inner = match InnerTransfer::new(context.clone()) {
+            Ok(inner) => inner,
+            Err(e) => return Err((data, e)),
+        };
+        let transfer_ptr = inner.as_ptr();
+        let transfer = Arc::new(Mutex::new(inner));
+
+        let mut buffer: Pin<Box<[u8]>> = data.into_boxed_slice().into();
+
+        let result = {
+            let state_ptr = Arc::into_raw(transfer.clone()) as *mut c_void;
+            let buffer: *mut u8 = buffer.as_mut_ptr();
+
+            unsafe {
+                libusb_fill_bulk_transfer(
+                    transfer_ptr,
+                    device.as_ptr(),
+                    endpoint,
+                    buffer,
+                    max_size,
+                    transfer_finished::<T> as _,
+                    state_ptr,
+                    timeout,
+                );
+            }
+
+            unsafe { libusb_submit_transfer(transfer_ptr) }
+        };
+
+        if let Err(e) = check_transfer_error(result) {
+            return Err((Pin::<Box<[u8]>>::into_inner(buffer).into_vec(), e));
+        }
+
+        Ok(Self {
+            inner: transfer,
+            _context: context,
+            buffer: Arc::new(Mutex::new(Some(buffer))),
+        })
+    }
+
+    /// Construct a new control transfer to transfer data to/from the device using a control
+    /// transfer and fills `data` with any data received during the transfer or writes the contents
+    /// of `data` to the device depending on the direction of `request_type`. The transfer will
+    /// claim ownership of `data` until the request completes, gets cancelled or errors out, upon
+    /// which the ownership of `data` is given back to the task awaiting this transfer.
+    ///
+    /// The parameters `request_type`, `request`, `value` and `index` specify the fields of the
+    /// control transfer setup packet (`bmRequestType`, `bmRequest`, `wValue` and `wIndex`
+    /// respectively). The values for each of these parameters shall be given in host-endian byte
+    /// order. The value for the `request_type` parameter can be built with the helper function
+    /// [request_type()](fn.request_type.html). The meaning of the other parameters depends on the
+    /// type of control request.
+    ///
+    /// As these parameters are stored in the first [`LIBUSB_CONTROL_SETUP_SIZE`] bytes of the
+    /// control request, the buffer must be at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the device for read requests. This data can be found starting at offset
+    /// [`LIBUSB_CONTROL_SETUP_SIZE`] in `data`. Otherwise for write requests, `n` bytes of `data`
+    /// were written to the device.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were transferred.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if buffer is not at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    ///
+    /// [`LIBUSB_CONTROL_SETUP_SIZE`]: rusb::constants::LIBUSB_CONTROL_SETUP_SIZE
+    pub fn new_control_transfer(
+        device: &DeviceHandle<T>,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<Self, (Vec<u8>, Error)> {
+        if data.len() < LIBUSB_CONTROL_SETUP_SIZE {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let context = device.context().clone();
+        // SAFETY: device.as_raw() must be a valid pointer.
+        let device = unsafe { NonNull::new_unchecked(device.as_raw()) };
+
+        let max_size: u16 = match (data.len() - LIBUSB_CONTROL_SETUP_SIZE).try_into() {
+            Ok(n) => n,
+            Err(_) => return Err((data, Error::InvalidParam)),
+        };
+
+        let timeout = timeout.as_millis() as c_uint;
+
+        let mut inner = match InnerTransfer::new(context.clone()) {
+            Ok(inner) => inner,
+            Err(e) => return Err((data, e)),
+        };
+        let transfer_ptr = inner.as_ptr();
+        let transfer = Arc::new(Mutex::new(inner));
+
+        let mut buffer: Pin<Box<[u8]>> = data.into_boxed_slice().into();
+
+        let result = {
+            let state_ptr = Arc::into_raw(transfer.clone()) as *mut c_void;
+            let buffer: *mut u8 = buffer.as_mut_ptr();
+
+            // SAFETY: buffer has at least LIBUSB_CONTROL_SETUP_SIZE bytes and is a valid pointer.
+            unsafe {
+                libusb_fill_control_setup(
+                    buffer,
+                    request_type,
+                    request,
+                    value,
+                    index,
+                    max_size
+                );
+            }
+
+            // SAFETY: transfer_ptr, device.as_ptr(), buffer, state_ptr are all valid. This is the
+            // only user of transfer_finished and transfer_finished gets state_ptr which is of the
+            // type `Arc<Mutex<InnerTransfer<T>>>` as expected. These pointers remain valid until
+            // `transfer_finished` gets called.
+            unsafe {
+                libusb_fill_control_transfer(
+                    transfer_ptr,
+                    device.as_ptr(),
+                    buffer,
+                    transfer_finished::<T> as _,
+                    state_ptr,
+                    timeout,
+                );
+            }
+
+            // SAFETY: we ensure that transfer_ptr and buffer are valid until completion,
+            // cancellation or an error occurs. In addition, as buffer is `Pin`, it is guaranteed
+            // to not move around while the transfer is in progress.
+            unsafe { libusb_submit_transfer(transfer_ptr) }
+        };
+
+        if let Err(e) = check_transfer_error(result) {
+            return Err((Pin::<Box<[u8]>>::into_inner(buffer).into_vec(), e));
+        }
+
+        Ok(Self {
+            inner: transfer,
+            _context: context,
+            buffer: Arc::new(Mutex::new(Some(buffer))),
+        })
+    }
+
+    /// Constructs a new interrupt transfer to transfer data to/from the interrupt endpoint with
+    /// the address given by the `endpoint` parameter and fills `data` with any data received from
+    /// the endpoint or writes the contents of `data` to the endpoint depending on the direction of
+    /// the endpoint. The transfer will claim ownership of `data` until the request completes, gets
+    /// cancelled or errors out, upon which the ownership of `data` is given back to the task
+    /// awaiting this transfer.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the endpoint for readable endpoints. Otherwise for writeable endpoints, `n`
+    /// bytes of `data` were written to the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were transferred.
+    ///
+    /// The errors returned by polling this transfer include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an output endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    pub fn new_interrupt_transfer(
+        device: &DeviceHandle<T>,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<Self, (Vec<u8>, Error)> {
+        let context = device.context().clone();
+        let device = unsafe { NonNull::new_unchecked(device.as_raw()) };
+
+        let max_size = data.len() as i32;
+        let timeout = timeout.as_millis() as c_uint;
+
+        let mut inner = match InnerTransfer::new(context.clone()) {
+            Ok(inner) => inner,
+            Err(e) => return Err((data, e)),
+        };
+        let transfer_ptr = inner.as_ptr();
+        let transfer = Arc::new(Mutex::new(inner));
+
+        let mut buffer: Pin<Box<[u8]>> = data.into_boxed_slice().into();
+
+        let result = {
+            let state_ptr = Arc::into_raw(transfer.clone()) as *mut c_void;
+            let buffer: *mut u8 = buffer.as_mut_ptr();
+
+            unsafe {
+                libusb_fill_interrupt_transfer(
+                    transfer_ptr,
+                    device.as_ptr(),
+                    endpoint,
+                    buffer,
+                    max_size,
+                    transfer_finished::<T> as _,
+                    state_ptr,
+                    timeout,
+                );
+            }
+
+            unsafe { libusb_submit_transfer(transfer_ptr) }
+        };
+
+        if let Err(e) = check_transfer_error(result) {
+            return Err((Pin::<Box<[u8]>>::into_inner(buffer).into_vec(), e));
+        }
+
+        Ok(Self {
+            inner: transfer,
+            _context: context,
+            buffer: Arc::new(Mutex::new(Some(buffer))),
+        })
+    }
+
+    /// Constructs a [`CancellationToken`] that can be used to cancel the USB transfer.
+    pub fn cancellation_token(&self) -> CancellationToken<T> {
+        CancellationToken {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait DeviceHandleExt {
+    /// Asynchronously reads from a bulk endpoint.
+    ///
+    /// This function attempts to asynchronously read from the bulk endpoint with the address given
+    /// by the `endpoint` parameter and fills `data` with any data received from the endpoint. This
+    /// function will claim ownership of `data` until the request completes, gets cancelled or
+    /// errors out, upon which the ownership of `data` is given back to the caller of this function.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_bulk_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were read.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an input endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    async fn read_bulk_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    /// Asynchronously reads data using a control transfer.
+    ///
+    /// This function attempts to asynchronously read data from the device using a control transfer
+    /// and fills `data` with any data received during the transfer. This function will claim
+    /// ownership of `data` until the request completes, gets cancelled or errors out, upon which
+    /// the ownership of `data` is given back to the caller of this function.
+    ///
+    /// The parameters `request_type`, `request`, `value` and `index` specify the fields of the
+    /// control transfer setup packet (`bmRequestType`, `bmRequest`, `wValue` and `wIndex`
+    /// respectively). The values for each of these parameters shall be given in host-endian byte
+    /// order. The value for the `request_type` parameter can be built with the helper function
+    /// [request_type()](fn.request_type.html). The meaning of the other parameters depends on the
+    /// type of control request.
+    ///
+    /// As these parameters are stored in the first [`LIBUSB_CONTROL_SETUP_SIZE`] bytes of the
+    /// control request, the buffer must be at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_control_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the device. This data can be found starting at offset
+    /// [`LIBUSB_CONTROL_SETUP_SIZE`] in `data`.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were read.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the `request_type` does not specify a read transfer.
+    ///  * `InvalidParam` if buffer is not at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    ///
+    /// [`LIBUSB_CONTROL_SETUP_SIZE`]: rusb::constants::LIBUSB_CONTROL_SETUP_SIZE
+    async fn read_control_async(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    /// Asynchronously reads from an interrupt endpoint.
+    ///
+    /// This function attempts to asynchronously read from the interrupt endpoint with the address
+    /// given by the `endpoint` parameter and fills `data` with any data received from the endpoint.
+    /// This function will claim ownership of `data` until the request completes, gets cancelled or
+    /// errors out, upon which the ownership of `data` is given back to the caller of this function.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_bulk_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((data, n))`, then `data` is populated with `n` bytes of data
+    /// received from the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were read.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an input endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    async fn read_interrupt_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    /// Asynchronously writes to a bulk endpoint.
+    ///
+    /// This function attempts to asynchronously write the contents of `data` to the bulk endpoint
+    /// with the address given by the `endpoint` parameter. This function will claim ownership of
+    /// `data` until the request completes, gets cancelled or errors out, upon which the ownership
+    /// of `data` is given back to the caller of this function.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_bulk_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((_, n))`, then `n` bytes of `data` were written to the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were written.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an output endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    async fn write_bulk_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    /// Asynchronously writes data using a control transfer.
+    ///
+    /// This function attempts to asynchronously write data to the device using a control transfer
+    /// and writes the contents of `data` during the transfer. This function will claim ownership
+    /// of `data` until the request completes, gets cancelled or errors out, upon which the
+    /// ownership of `data` is given back to the caller of this function.
+    ///
+    /// The parameters `request_type`, `request`, `value` and `index` specify the fields of the
+    /// control transfer setup packet (`bmRequestType`, `bmRequest`, `wValue` and `wIndex`
+    /// respectively). The values for each of these parameters shall be given in host-endian byte
+    /// order. The value for the `request_type` parameter can be built with the helper function
+    /// [request_type()](fn.request_type.html). The meaning of the other parameters depends on the
+    /// type of control request.
+    ///
+    /// As these parameters are stored in the first [`LIBUSB_CONTROL_SETUP_SIZE`] bytes of the
+    /// control request, the buffer must be at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    /// The actual data must start at offset [`LIBUSB_CONTROL_SETUP_SIZE`].
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_control_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((_, n))`, then `n` bytes have been written to the device.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were written.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the `request_type` does not specify a write transfer.
+    ///  * `InvalidParam` if buffer is not at least [`LIBUSB_CONTROL_SETUP_SIZE`] bytes in size.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    ///
+    /// [`LIBUSB_CONTROL_SETUP_SIZE`]: rusb::constants::LIBUSB_CONTROL_SETUP_SIZE
+    async fn write_control_async(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+
+    /// Asynchronously writes to an interrupt endpoint.
+    ///
+    /// This function attempts to asynchronously write the contents of `data` to the interrupt
+    /// endpoint with the address given by the `endpoint` parameter. This function will claim
+    /// ownership of `data` until the request completes, gets cancelled or errors out, upon which
+    /// the ownership of `data` is given back to the caller of this function.
+    ///
+    /// The function blocks up to the amount of time specified by `timeout`. Minimal `timeout` is 1
+    /// milliseconds, anything smaller will result in an infinite block.
+    ///
+    /// In case you want the ability to cancel the USB transfer, consider using
+    /// [`Transfer::new_interrupt_transfer()`] instead.
+    ///
+    /// If the return value is `Ok((_, n))`, then `n` bytes of `data` were written to the endpoint.
+    ///
+    /// ## Errors
+    ///
+    /// If this function encounters any form of error while fulfilling the transfer request, an
+    /// error variant will be returned. If an error variant is returned, no bytes were written.
+    ///
+    /// The errors returned by this function include:
+    ///
+    ///  * `InvalidParam` if the endpoint is not an output endpoint.
+    ///  * `Timeout` if the transfer timed out.
+    ///  * `Interrupted` if the transfer was cancelled.
+    ///  * `Pipe` if the endpoint halted.
+    ///  * `NoDevice` if the device has been disconnected.
+    ///  * `Io` if the transfer encountered an I/O error.
+    async fn write_interrupt_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)>;
+}
+
+#[async_trait]
+impl<T: UsbContext> DeviceHandleExt for DeviceHandle<T> {
+    async fn read_bulk_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if endpoint & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_IN {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_bulk_transfer(
+            self,
+            endpoint,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+
+    async fn read_control_async(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if request_type & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_IN {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_control_transfer(
+            self,
+            request_type,
+            request,
+            value,
+            index,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+
+    async fn read_interrupt_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if endpoint & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_IN {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_interrupt_transfer(
+            self,
+            endpoint,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+
+    async fn write_bulk_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if endpoint & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_OUT {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_bulk_transfer(
+            self,
+            endpoint,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+
+    async fn write_control_async(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if request_type & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_OUT {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_control_transfer(
+            self,
+            request_type,
+            request,
+            value,
+            index,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+
+    async fn write_interrupt_async(
+        &self,
+        endpoint: u8,
+        data: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<(Vec<u8>, usize), (Vec<u8>, Error)> {
+        if endpoint & LIBUSB_ENDPOINT_DIR_MASK != LIBUSB_ENDPOINT_OUT {
+            return Err((data, Error::InvalidParam));
+        }
+
+        let transfer = Transfer::new_interrupt_transfer(
+            self,
+            endpoint,
+            data,
+            timeout,
+        )?;
+
+        Ok(transfer.await?)
+    }
+}

--- a/src/config_descriptor.rs
+++ b/src/config_descriptor.rs
@@ -21,6 +21,21 @@ unsafe impl Sync for ConfigDescriptor {}
 unsafe impl Send for ConfigDescriptor {}
 
 impl ConfigDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        unsafe { (*self.descriptor).bLength }
+    }
+
+    /// Returns the total length in bytes of data returned for this configuration: all interfaces and endpoints
+    pub fn total_length(&self) -> u16 {
+        unsafe { (*self.descriptor).wTotalLength }
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        unsafe { (*self.descriptor).bDescriptorType }
+    }
+
     /// Returns the configuration number.
     pub fn number(&self) -> u8 {
         unsafe { (*self.descriptor).bConfigurationValue }

--- a/src/device_descriptor.rs
+++ b/src/device_descriptor.rs
@@ -10,6 +10,16 @@ pub struct DeviceDescriptor {
 }
 
 impl DeviceDescriptor {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the device's maximum supported USB version.
     pub fn usb_version(&self) -> Version {
         Version::from_bcd(self.descriptor.bcdUSB)

--- a/src/device_handle.rs
+++ b/src/device_handle.rs
@@ -2,6 +2,7 @@ use std::{
     fmt::{self, Debug},
     mem,
     ptr::NonNull,
+    sync::Mutex,
     time::Duration,
 };
 
@@ -109,18 +110,18 @@ impl<'a> Iterator for ClaimedInterfacesIter<'a> {
 }
 
 /// A handle to an open USB device.
-#[derive(Eq, PartialEq)]
 pub struct DeviceHandle<T: UsbContext> {
     context: T,
     handle: Option<NonNull<libusb_device_handle>>,
-    interfaces: ClaimedInterfaces,
+    interfaces: Mutex<ClaimedInterfaces>,
 }
 
 impl<T: UsbContext> Drop for DeviceHandle<T> {
     /// Closes the device.
     fn drop(&mut self) {
         unsafe {
-            for iface in self.interfaces.iter() {
+            let interfaces = self.interfaces.lock().unwrap();
+            for iface in interfaces.iter() {
                 libusb_release_interface(self.as_raw(), iface as c_int);
             }
 
@@ -139,10 +140,20 @@ impl<T: UsbContext> Debug for DeviceHandle<T> {
         f.debug_struct("DeviceHandle")
             .field("device", &self.device())
             .field("handle", &self.handle)
-            .field("interfaces", &self.interfaces)
+            .field("interfaces", &*self.interfaces.lock().unwrap())
             .finish()
     }
 }
+
+impl<T: UsbContext + PartialEq> PartialEq for DeviceHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.context == other.context
+            && self.handle == other.handle
+            && *self.interfaces.lock().unwrap() == *other.interfaces.lock().unwrap()
+    }
+}
+
+impl<T: UsbContext + PartialEq> Eq for DeviceHandle<T> {}
 
 impl<T: UsbContext> DeviceHandle<T> {
     /// Get the raw libusb_device_handle pointer, for advanced use in unsafe code.
@@ -164,7 +175,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     ///
     /// Panics if you have any claimed interfaces on this handle.
     pub fn into_raw(mut self) -> *mut libusb_device_handle {
-        assert_eq!(self.interfaces.size(), 0);
+        assert_eq!(self.interfaces.lock().unwrap().size(), 0);
         match self.handle.take() {
             Some(it) => it.as_ptr(),
             _ => unreachable!(),
@@ -197,7 +208,7 @@ impl<T: UsbContext> DeviceHandle<T> {
         DeviceHandle {
             context,
             handle: Some(handle),
-            interfaces: ClaimedInterfaces::new(),
+            interfaces: Mutex::new(ClaimedInterfaces::new()),
         }
     }
 
@@ -210,25 +221,25 @@ impl<T: UsbContext> DeviceHandle<T> {
     }
 
     /// Sets the device's active configuration.
-    pub fn set_active_configuration(&mut self, config: u8) -> crate::Result<()> {
+    pub fn set_active_configuration(&self, config: u8) -> crate::Result<()> {
         try_unsafe!(libusb_set_configuration(self.as_raw(), c_int::from(config)));
         Ok(())
     }
 
     /// Puts the device in an unconfigured state.
-    pub fn unconfigure(&mut self) -> crate::Result<()> {
+    pub fn unconfigure(&self) -> crate::Result<()> {
         try_unsafe!(libusb_set_configuration(self.as_raw(), -1));
         Ok(())
     }
 
     /// Resets the device.
-    pub fn reset(&mut self) -> crate::Result<()> {
+    pub fn reset(&self) -> crate::Result<()> {
         try_unsafe!(libusb_reset_device(self.as_raw()));
         Ok(())
     }
 
     /// Clear the halt/stall condition for an endpoint.
-    pub fn clear_halt(&mut self, endpoint: u8) -> crate::Result<()> {
+    pub fn clear_halt(&self, endpoint: u8) -> crate::Result<()> {
         try_unsafe!(libusb_clear_halt(self.as_raw(), endpoint));
         Ok(())
     }
@@ -247,7 +258,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// Detaches an attached kernel driver from the device.
     ///
     /// This method is not supported on all platforms.
-    pub fn detach_kernel_driver(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn detach_kernel_driver(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_detach_kernel_driver(
             self.as_raw(),
             c_int::from(iface)
@@ -258,7 +269,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// Attaches a kernel driver to the device.
     ///
     /// This method is not supported on all platforms.
-    pub fn attach_kernel_driver(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn attach_kernel_driver(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_attach_kernel_driver(
             self.as_raw(),
             c_int::from(iface)
@@ -275,7 +286,7 @@ impl<T: UsbContext> DeviceHandle<T> {
     /// On platforms which do not have support, this function will
     /// return `Error::NotSupported`, and rusb will continue as if
     /// this function was never called.
-    pub fn set_auto_detach_kernel_driver(&mut self, auto_detach: bool) -> crate::Result<()> {
+    pub fn set_auto_detach_kernel_driver(&self, auto_detach: bool) -> crate::Result<()> {
         try_unsafe!(libusb_set_auto_detach_kernel_driver(
             self.as_raw(),
             auto_detach.into()
@@ -287,21 +298,21 @@ impl<T: UsbContext> DeviceHandle<T> {
     ///
     /// An interface must be claimed before operating on it. All claimed interfaces are released
     /// when the device handle goes out of scope.
-    pub fn claim_interface(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn claim_interface(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_claim_interface(self.as_raw(), c_int::from(iface)));
-        self.interfaces.insert(iface);
+        self.interfaces.lock().unwrap().insert(iface);
         Ok(())
     }
 
     /// Releases a claimed interface.
-    pub fn release_interface(&mut self, iface: u8) -> crate::Result<()> {
+    pub fn release_interface(&self, iface: u8) -> crate::Result<()> {
         try_unsafe!(libusb_release_interface(self.as_raw(), c_int::from(iface)));
-        self.interfaces.remove(iface);
+        self.interfaces.lock().unwrap().remove(iface);
         Ok(())
     }
 
     /// Sets an interface's active setting.
-    pub fn set_alternate_setting(&mut self, iface: u8, setting: u8) -> crate::Result<()> {
+    pub fn set_alternate_setting(&self, iface: u8, setting: u8) -> crate::Result<()> {
         try_unsafe!(libusb_set_interface_alt_setting(
             self.as_raw(),
             c_int::from(iface),

--- a/src/endpoint_descriptor.rs
+++ b/src/endpoint_descriptor.rs
@@ -10,6 +10,16 @@ pub struct EndpointDescriptor<'a> {
 }
 
 impl<'a> EndpointDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the endpoint's address.
     pub fn address(&self) -> u8 {
         self.descriptor.bEndpointAddress

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
 use std::{fmt, result};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use libusb1_sys::constants::*;
 
 /// A result of a function that may return a `Error`.
@@ -7,6 +10,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// Errors returned by the `libusb` library.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Error {
     /// Input/output error.
     Io,

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,10 +1,14 @@
 use libc::c_int;
 use libusb1_sys::constants::*;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Device speeds. Indicates the speed at which a device is operating.
 /// - [libusb_supported_speed](http://libusb.sourceforge.net/api-1.0/group__libusb__dev.html#ga1454797ecc0de4d084c1619c420014f6)
 /// - [USB release versions](https://en.wikipedia.org/wiki/USB#Release_versions)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum Speed {
     /// The operating system doesn't know the device speed.
@@ -41,6 +45,7 @@ pub(crate) fn speed_from_libusb(n: c_int) -> Speed {
 
 /// Transfer and endpoint directions.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Direction {
     /// Direction for read (device to host) transfers.
     In,
@@ -51,6 +56,7 @@ pub enum Direction {
 
 /// An endpoint's transfer type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TransferType {
     /// Control endpoint.
     Control,
@@ -67,6 +73,7 @@ pub enum TransferType {
 
 /// Isochronous synchronization mode.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SyncType {
     /// No synchronisation.
     NoSync,
@@ -83,6 +90,7 @@ pub enum SyncType {
 
 /// Isochronous usage type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UsageType {
     /// Data endpoint.
     Data,
@@ -99,6 +107,7 @@ pub enum UsageType {
 
 /// Types of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RequestType {
     /// Requests that are defined by the USB standard.
     Standard,
@@ -115,6 +124,7 @@ pub enum RequestType {
 
 /// Recipients of control transfers.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Recipient {
     /// The recipient is a device.
     Device,
@@ -144,6 +154,7 @@ pub enum Recipient {
 /// The intended use case of `Version` is to extract meaning from the version fields in USB
 /// descriptors, such as `bcdUSB` and `bcdDevice` in device descriptors.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version(pub u8, pub u8, pub u8);
 
 impl Version {

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -51,6 +51,16 @@ pub struct InterfaceDescriptor<'a> {
 }
 
 impl<'a> InterfaceDescriptor<'a> {
+    /// Returns the size of the descriptor in bytes
+    pub fn length(&self) -> u8 {
+        self.descriptor.bLength
+    }
+
+    /// Returns the descriptor type
+    pub fn descriptor_type(&self) -> u8 {
+        self.descriptor.bDescriptorType
+    }
+
     /// Returns the interface's number.
     pub fn interface_number(&self) -> u8 {
         self.descriptor.bInterfaceNumber

--- a/src/interface_descriptor.rs
+++ b/src/interface_descriptor.rs
@@ -101,11 +101,9 @@ impl<'a> InterfaceDescriptor<'a> {
 
     /// Returns an iterator over the interface's endpoint descriptors.
     pub fn endpoint_descriptors(&self) -> EndpointDescriptors<'a> {
-        let endpoints = unsafe {
-            slice::from_raw_parts(
-                self.descriptor.endpoint,
-                self.descriptor.bNumEndpoints as usize,
-            )
+        let endpoints = match self.descriptor.bNumEndpoints {
+            0 => &[],
+            n => unsafe { slice::from_raw_parts(self.descriptor.endpoint, n as usize) },
         };
 
         EndpointDescriptors {

--- a/src/language.rs
+++ b/src/language.rs
@@ -17,7 +17,7 @@ impl Language {
     /// Returns the language's 16-bit `LANGID`.
     ///
     /// Each language's `LANGID` is defined by the USB forum
-    /// <http://www.usb.org/developers/docs/USB_LANGIDs.pdf>.
+    /// <https://learn.microsoft.com/en-us/windows/win32/intl/language-identifier-constants-and-strings>.
     pub fn lang_id(self) -> u16 {
         self.raw
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use libusb1_sys::constants;
 pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
-    context::{Context, GlobalContext, LogLevel, UsbContext},
+    context::{Context, GlobalContext, LogCallbackMode, LogLevel, UsbContext},
     device::Device,
     device_descriptor::DeviceDescriptor,
     device_handle::DeviceHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub use libusb1_sys as ffi;
 pub use libusb1_sys::constants;
 
+#[cfg(unix)]
+pub use crate::options::disable_device_discovery;
 pub use crate::{
     config_descriptor::{ConfigDescriptor, Interfaces},
     context::{Context, GlobalContext, LogLevel, UsbContext},

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,3 +37,21 @@ enum OptionInner {
     #[cfg_attr(not(windows), allow(dead_code))] // only constructed on Windows
     UseUsbdk,
 }
+
+/// Disable device scanning in `libusb` init.
+///
+/// Hotplug functionality will also be deactivated.
+///
+/// This is a Linux only option and it must be set before any [`Context`]
+/// creation.
+///
+/// The option is useful in combination with [`Context::open_device_with_fd()`],
+/// which can access a device directly without prior device scanning.
+#[cfg(unix)]
+pub fn disable_device_discovery() -> crate::Result<()> {
+    try_unsafe!(libusb1_sys::libusb_set_option(
+        std::ptr::null_mut(),
+        LIBUSB_OPTION_NO_DEVICE_DISCOVERY
+    ));
+    Ok(())
+}


### PR DESCRIPTION
Hey @StephanvanSchaik,

I am opening this PR to report a memory corruption issue with your rusb-async implementation in your [async-v2](https://github.com/StephanvanSchaik/rusb) branch, as the "Issues" tab is not open in this repository. I will close this PR once I figure this out.

## Background
I'm using rusb-async for bulk read operations in an MTP implementation. I'm encountering intermittent memory corruption issues ONLY on **Linux**, the application works perfectly on macOS and Windows.

## Issue Description

When performing async bulk read operations, I intermittently get buffer drop errors on Linux which primarily throw `SIGSEGV (signal SIGSEGV: invalid address (fault address: 0x0))`. These crashes occur inconsistently, about 40%–60% of the time, especially when the returned `Box<[u8]>` buffer is not consumed. 
Even when the buffer is fully consumed by writing to a `std::io::Sink` that discards the data, the problem still appears, though less frequently (20%–30%).


## Error Types Encountered
The primary error is:
```
Signal: SIGSEGV (signal SIGSEGV: invalid address (fault address: 0x0))
```

Stack traces typically show (expand to see):

<details>  
<summary>Stack trace logs</summary>  
```
[libc.so.6] unlink_chunk 0x000076bbd10a9af7
[libc.so.6] _int_free_merge_chunk 0x000076bbd10ab025
[libc.so.6] _int_free 0x000076bbd10ab43a
[libc.so.6] __GI___libc_free 0x000076bbd10addae
[Inlined] [mtp_rs-0012dd38f3091b50] alloc::alloc::dealloc alloc.rs:114
[mtp_rs-0012dd38f3091b50] <alloc::alloc::Global as core::alloc::Allocator>::deallocate alloc.rs:271
[mtp_rs-0012dd38f3091b50] <alloc::boxed::Box<T,A> as core::ops::drop::Drop>::drop boxed.rs:1661
[mtp_rs-0012dd38f3091b50] core::ptr::drop_in_place<alloc::boxed::Box<[u8]>> mod.rs:799
[mtp_rs-0012dd38f3091b50] <mtp_rs::transaction::async_transfer::read::AsyncBulkRead as futures_core::stream::Stream>::poll_next read.rs:624
[mtp_rs-0012dd38f3091b50] futures_util::stream::stream::StreamExt::poll_next_unpin mod.rs:1638
[mtp_rs-0012dd38f3091b50] <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll next.rs:32
[mtp_rs-0012dd38f3091b50] mtp_rs::transaction::bulk_read::BulkRead::run::{{closure}} bulk_read.rs:262
[mtp_rs-0012dd38f3091b50] <core::pin::Pin<P> as core::future::future::Future>::poll future.rs:124
[mtp_rs-0012dd38f3091b50] mtp_rs::transaction::<impl mtp_rs::definitions::media_device::MediaDevice>::bulk_read_from_device::{{closure}} mod.rs:545
[mtp_rs-0012dd38f3091b50] <core::pin::Pin<P> as core::future::future::Future>::poll future.rs:124
[mtp_rs-0012dd38f3091b50] mtp_rs::transaction::<impl mtp_rs::definitions::media_device::MediaDevice>::run_full_txn::{{closure}} mod.rs:218
[mtp_rs-0012dd38f3091b50] mtp_rs::operations::<impl mtp_rs::definitions::media_device::MediaDevice>::initiate_txn::{{closure}} operations.rs:1102
[mtp_rs-0012dd38f3091b50] mtp_rs::apis::<impl mtp_rs::definitions::media_device::MediaDevice>::get_object::{{closure}} apis.rs:1066
[mtp_rs-0012dd38f3091b50] <mtp_rs::definitions::progress_tracker::GetObjectBuilder as mtp_rs::definitions::progress_tracker::ProgressTracker>::run_with_progress::{{closure}} progress_tracker.rs:133
[mtp_rs-0012dd38f3091b50] mtp_rs::apis::<impl mtp_rs::definitions::media_device::MediaDevice>::get_object_with_progress::{{closure}} apis.rs:1189
[mtp_rs-0012dd38f3091b50] mtp_rs::test_suite_helpers::ObjectTxnTestSuite::get_object::{{closure}} test_suite_helpers.rs:865
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::TestDeviceCancellableApis::test_cancellable_get_object::{{closure}} cancellable_apis.rs:1422
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::TestDeviceCancellableApis::test_cancellable_send_object::{{closure}} cancellable_apis.rs:574
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::TestDeviceCancellableApis::test_cancellable_file_transfer::{{closure}} cancellable_apis.rs:260
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::test_device_cancellable_apis::{{closure}}::{{closure}} cancellable_apis.rs:2694
[mtp_rs-0012dd38f3091b50] <core::pin::Pin<P> as core::future::future::Future>::poll future.rs:124
[mtp_rs-0012dd38f3091b50] tokio::runtime::park::CachedParkThread::block_on::{{closure}} park.rs:285
[Inlined] [mtp_rs-0012dd38f3091b50] tokio::task::coop::with_budget mod.rs:167
[Inlined] [mtp_rs-0012dd38f3091b50] tokio::task::coop::budget mod.rs:133
[mtp_rs-0012dd38f3091b50] tokio::runtime::park::CachedParkThread::block_on park.rs:285
[mtp_rs-0012dd38f3091b50] tokio::runtime::context::blocking::BlockingRegionGuard::block_on blocking.rs:66
[mtp_rs-0012dd38f3091b50] tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}} mod.rs:87
[mtp_rs-0012dd38f3091b50] tokio::runtime::context::runtime::enter_runtime runtime.rs:65
[mtp_rs-0012dd38f3091b50] tokio::runtime::scheduler::multi_thread::MultiThread::block_on mod.rs:86
[mtp_rs-0012dd38f3091b50] tokio::runtime::runtime::Runtime::block_on_inner runtime.rs:358
[mtp_rs-0012dd38f3091b50] tokio::runtime::runtime::Runtime::block_on runtime.rs:330
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::test_device_cancellable_apis::{{closure}} cancellable_apis.rs:2732
[mtp_rs-0012dd38f3091b50] core::ops::function::FnOnce::call_once function.rs:250
[mtp_rs-0012dd38f3091b50] serial_test::serial_code_lock::local_serial_core serial_code_lock.rs:36
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::test_device_cancellable_apis cancellable_apis.rs:2632
[mtp_rs-0012dd38f3091b50] mtp_rs::tests::cancellable_apis::test_device_cancellable_apis::{{closure}} cancellable_apis.rs:2632
[mtp_rs-0012dd38f3091b50] core::ops::function::FnOnce::call_once function.rs:250
[Inlined] [mtp_rs-0012dd38f3091b50] core::ops::function::FnOnce::call_once function.rs:250
[mtp_rs-0012dd38f3091b50] test::__rust_begin_short_backtrace lib.rs:648
[Inlined] [mtp_rs-0012dd38f3091b50] test::run_test_in_process::{{closure}} lib.rs:671
[Inlined] [mtp_rs-0012dd38f3091b50] <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once unwind_safe.rs:272
[Inlined] [mtp_rs-0012dd38f3091b50] std::panicking::catch_unwind::do_call panicking.rs:589
[Inlined] [mtp_rs-0012dd38f3091b50] std::panicking::catch_unwind panicking.rs:552
[Inlined] [mtp_rs-0012dd38f3091b50] std::panic::catch_unwind panic.rs:359
[Inlined] [mtp_rs-0012dd38f3091b50] test::run_test_in_process lib.rs:671
[mtp_rs-0012dd38f3091b50] test::run_test::{{closure}} lib.rs:592
[Inlined] [mtp_rs-0012dd38f3091b50] test::run_test::{{closure}} lib.rs:622
[mtp_rs-0012dd38f3091b50] std::sys::backtrace::__rust_begin_short_backtrace backtrace.rs:152
[Inlined] [mtp_rs-0012dd38f3091b50] std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}} mod.rs:559
[Inlined] [mtp_rs-0012dd38f3091b50] <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once unwind_safe.rs:272
[Inlined] [mtp_rs-0012dd38f3091b50] std::panicking::catch_unwind::do_call panicking.rs:589
[Inlined] [mtp_rs-0012dd38f3091b50] std::panicking::catch_unwind panicking.rs:552
[Inlined] [mtp_rs-0012dd38f3091b50] std::panic::catch_unwind panic.rs:359
[Inlined] [mtp_rs-0012dd38f3091b50] std::thread::Builder::spawn_unchecked_::{{closure}} mod.rs:557
[mtp_rs-0012dd38f3091b50] core::ops::function::FnOnce::call_once{{vtable.shim}} function.rs:250
[Inlined] [mtp_rs-0012dd38f3091b50] <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once boxed.rs:1966
[mtp_rs-0012dd38f3091b50] std::sys::pal::unix::thread::Thread::new::thread_start thread.rs:107
[libc.so.6] start_thread 0x000076bbd109caa4
[libc.so.6] __clone3 0x000076bbd1129c3c
```
</details>  


Additional heap corruption errors I've encountered include:
* **"malloc(): unsorted double linked list corrupted"** - SIGABRT (signal 6)  
* **"free(): corrupted unsorted chunks"**
* **"malloc(): corrupted top size"**

## Investigation Steps
Using my IDE debugger, I traced the issue to the `Box<[u8]>` returned from the USB transfer operations. On Linux, the crash is mostly triggered at the point these buffers are dropped, either automatically when going out of scope or explicitly when freed.

The issue appears to be related to the usage of Box<[u8]> returned from bulk_read. The crash only shows up when these buffers are either not consumed or dropped, but the exact root cause is unclear at this point.

Thanks for the amazing implementation of rusb async implementation. Any insights into this Linux-specific behavior would be greatly appreciated.

Screenshots:
- 
<img width="2010" height="1270" alt="Screenshot from 2025-09-18 23-43-22" src="https://github.com/user-attachments/assets/3e766bcd-8629-41f0-b934-cb6e7851d551" />

- 
<img width="2239" height="1270" alt="Screenshot from 2025-09-19 01-33-27" src="https://github.com/user-attachments/assets/ae47db12-6647-4739-926e-3d07cc76cd92" />


